### PR TITLE
Adaption and fixes in DoubleMLData

### DIFF
--- a/doubleml/double_ml_data.py
+++ b/doubleml/double_ml_data.py
@@ -412,3 +412,6 @@ class DoubleMLData:
             if not d_cols_set.isdisjoint(z_cols_set):
                 raise ValueError('At least one variable/column is set as treatment variable (``d_cols``) and '
                                  'instrumental variable in ``z_cols``.')
+            if not x_cols_set.isdisjoint(z_cols_set):
+                raise ValueError('At least one variable/column is set as covariate (``x_cols``) and instrumental '
+                                 'variable in ``z_cols``.')

--- a/doubleml/double_ml_data.py
+++ b/doubleml/double_ml_data.py
@@ -373,6 +373,8 @@ class DoubleMLData:
             raise ValueError('Invalid treatment_var. '
                              f'{treatment_var} is not in d_cols.')
         if self.use_other_treat_as_covariate:
+            # note that the following line needs to be adapted in case an intersection of x_cols and d_cols as allowed
+            # (see https://github.com/DoubleML/doubleml-for-py/issues/83)
             xd_list = self.x_cols + self.d_cols
             xd_list.remove(treatment_var)
         else:
@@ -400,6 +402,8 @@ class DoubleMLData:
         if not y_col_set.isdisjoint(d_cols_set):
             raise ValueError(f'{str(self.y_col)} cannot be set as outcome variable ``y_col`` and treatment variable in '
                              '``d_cols``.')
+        # note that the line xd_list = self.x_cols + self.d_cols in method set_x_d needs adaption if an intersection of
+        # x_cols and d_cols as allowed (see https://github.com/DoubleML/doubleml-for-py/issues/83)
         if not d_cols_set.isdisjoint(x_cols_set):
             raise ValueError('At least one variable/column is set as treatment variable (``d_cols``) and as covariate'
                              '(``x_cols``). Consider using parameter ``use_other_treat_as_covariate``.')

--- a/doubleml/double_ml_data.py
+++ b/doubleml/double_ml_data.py
@@ -253,10 +253,10 @@ class DoubleMLData:
         else:
             # x_cols defaults to all columns but y_col, d_cols and z_cols
             if self.z_cols is not None:
-                y_d_z = set.union(set(self.y_col), set(self.d_cols), set(self.z_cols))
+                y_d_z = set.union({self.y_col}, set(self.d_cols), set(self.z_cols))
                 x_cols = [col for col in self.data.columns if col not in y_d_z]
             else:
-                y_d = set.union(set(self.y_col), set(self.d_cols))
+                y_d = set.union({self.y_col}, set(self.d_cols))
                 x_cols = [col for col in self.data.columns if col not in y_d]
             self._x_cols = x_cols
         if reset_value:

--- a/doubleml/tests/test_dml_data.py
+++ b/doubleml/tests/test_dml_data.py
@@ -271,3 +271,32 @@ def test_use_other_treat_as_covariate():
     msg = r"treatment_var must be of str type. \['d1', 'd2'\] of type <class 'list'> was passed."
     with pytest.raises(TypeError, match=msg):
         dml_data.set_x_d(['d1', 'd2'])
+
+
+@pytest.mark.ci
+def test_disjoint_sets():
+    np.random.seed(3141)
+    df = pd.DataFrame(np.tile(np.arange(4), (4, 1)),
+                      columns=['yy', 'dd1', 'xx1', 'xx2'])
+
+    msg = (r'At least one variable/column is set as treatment variable \(``d_cols``\) and as covariate\(``x_cols``\). '
+           'Consider using parameter ``use_other_treat_as_covariate``.')
+    with pytest.raises(ValueError, match=msg):
+        _ = DoubleMLData(df, y_col='yy', d_cols=['dd1', 'xx1'], x_cols=['xx1', 'xx2'])
+    msg = 'yy cannot be set as outcome variable ``y_col`` and treatment variable in ``d_cols``'
+    with pytest.raises(ValueError, match=msg):
+        _ = DoubleMLData(df, y_col='yy', d_cols=['dd1', 'yy'], x_cols=['xx1', 'xx2'])
+    msg = 'yy cannot be set as outcome variable ``y_col`` and covariate in ``x_cols``'
+    with pytest.raises(ValueError, match=msg):
+        _ = DoubleMLData(df, y_col='yy', d_cols=['dd1'], x_cols=['xx1', 'yy', 'xx2'])
+    msg = 'yy cannot be set as outcome variable ``y_col`` and instrumental variable in ``z_cols``'
+    with pytest.raises(ValueError, match=msg):
+        _ = DoubleMLData(df, y_col='yy', d_cols=['dd1'], x_cols=['xx1', 'xx2'], z_cols='yy')
+    msg = (r'At least one variable/column is set as treatment variable \(``d_cols``\) and instrumental variable in '
+           '``z_cols``.')
+    with pytest.raises(ValueError, match=msg):
+        _ = DoubleMLData(df, y_col='yy', d_cols=['dd1'], x_cols=['xx1', 'xx2'], z_cols=['dd1'])
+    msg = (r'At least one variable/column is set as covariate \(``x_cols``\) and instrumental variable in '
+           '``z_cols``.')
+    with pytest.raises(ValueError, match=msg):
+        _ = DoubleMLData(df, y_col='yy', d_cols=['dd1'], x_cols=['xx1', 'xx2'], z_cols='xx2')

--- a/doubleml/tests/test_dml_data.py
+++ b/doubleml/tests/test_dml_data.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+import pandas as pd
 
 from doubleml import DoubleMLData, DoubleMLPLR
 from doubleml.datasets import make_plr_CCDDHNR2018, _make_pliv_data, make_pliv_CHS2015
@@ -102,6 +103,14 @@ def test_dml_data_no_instr():
     dml_data = DoubleMLData.from_arrays(x, y, d)
     assert dml_data.z is None
     assert dml_data.n_instr == 0
+
+
+@pytest.mark.ci
+def test_x_cols_setter_defaults():
+    df = pd.DataFrame(np.tile(np.arange(4), (4, 1)),
+                      columns=['yy', 'dd', 'xx1', 'xx2'])
+    dml_data = DoubleMLData(df, y_col='yy', d_cols='dd')
+    assert dml_data.x_cols == ['xx1', 'xx2']
 
 
 @pytest.mark.ci


### PR DESCRIPTION
- Fixes #95
- Via exception handling, we now disallow that the same variable/column gets assigned to multiple roles (like `y_col` and `d_cols`, etc.). Note that there is still the option `use_other_treat_as_covariate`. This fixes #84.
- As we disallow an intersection between `d_cols` and `x_cols`, #83 is also fixed. Note that https://github.com/DoubleML/doubleml-for-py/blob/be32d1f97703222eacd472166b858fee944f4e93/doubleml/double_ml_data.py#L371 is not a set union. So it is not safe to be used if the intersection is non-empty. Still it preserves the order, which `set.union()` does not. In the code a corresponding reminder has been added, so #83 can be closed.