### PR TITLE
prevent using the subclassed methods _check_score and _check_data when constructing DoubleML objects

### DIFF
--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -31,7 +31,6 @@ class DoubleML(ABC):
         if not isinstance(obj_dml_data, DoubleMLData):
             raise TypeError('The data must be of DoubleMLData type. '
                             f'{str(obj_dml_data)} of type {str(type(obj_dml_data))} was passed.')
-        self._check_data(obj_dml_data)
         self._dml_data = obj_dml_data
 
         # initialize learners and parameters which are set model specific
@@ -73,7 +72,7 @@ class DoubleML(ABC):
             raise ValueError('dml_procedure must be "dml1" or "dml2". '
                              f'Got {str(dml_procedure)}.')
         self._dml_procedure = dml_procedure
-        self._score = self._check_score(score)
+        self._score = score
 
         if (self.n_folds == 1) & self.apply_cross_fitting:
             warnings.warn('apply_cross_fitting is set to False. Cross-fitting is not supported for n_folds = 1.')
@@ -891,14 +890,6 @@ class DoubleML(ABC):
 
     @abstractmethod
     def _initialize_ml_nuisance_params(self):
-        pass
-
-    @abstractmethod
-    def _check_score(self, score):
-        pass
-
-    @abstractmethod
-    def _check_data(self, obj_dml_data):
         pass
 
     @abstractmethod

--- a/doubleml/double_ml_iivm.py
+++ b/doubleml/double_ml_iivm.py
@@ -134,6 +134,9 @@ class DoubleMLIIVM(DoubleML):
                          dml_procedure,
                          draw_sample_splitting,
                          apply_cross_fitting)
+
+        self._check_data(self._dml_data)
+        self._check_score(self.score)
         _ = self._check_learner(ml_g, 'ml_g', regressor=True, classifier=False)
         _ = self._check_learner(ml_m, 'ml_m', regressor=False, classifier=True)
         _ = self._check_learner(ml_r, 'ml_r', regressor=False, classifier=True)
@@ -182,7 +185,7 @@ class DoubleMLIIVM(DoubleML):
             if not callable(score):
                 raise TypeError('score should be either a string or a callable. '
                                 '%r was passed.' % score)
-        return score
+        return
 
     def _check_data(self, obj_dml_data):
         one_treat = (obj_dml_data.n_treat == 1)

--- a/doubleml/double_ml_irm.py
+++ b/doubleml/double_ml_irm.py
@@ -114,6 +114,9 @@ class DoubleMLIRM(DoubleML):
                          dml_procedure,
                          draw_sample_splitting,
                          apply_cross_fitting)
+
+        self._check_data(self._dml_data)
+        self._check_score(self.score)
         _ = self._check_learner(ml_g, 'ml_g', regressor=True, classifier=False)
         _ = self._check_learner(ml_m, 'ml_m', regressor=False, classifier=True)
         self._learner = {'ml_g': ml_g, 'ml_m': ml_m}
@@ -142,7 +145,7 @@ class DoubleMLIRM(DoubleML):
             if not callable(score):
                 raise TypeError('score should be either a string or a callable. '
                                 '%r was passed.' % score)
-        return score
+        return
 
     def _check_data(self, obj_dml_data):
         if obj_dml_data.z_cols is not None:

--- a/doubleml/double_ml_pliv.py
+++ b/doubleml/double_ml_pliv.py
@@ -106,6 +106,9 @@ class DoubleMLPLIV(DoubleML):
                          dml_procedure,
                          draw_sample_splitting,
                          apply_cross_fitting)
+
+        self._check_data(self._dml_data)
+        self._check_score(self.score)
         self.partialX = True
         self.partialZ = False
         _ = self._check_learner(ml_g, 'ml_g', regressor=True, classifier=False)
@@ -137,6 +140,8 @@ class DoubleMLPLIV(DoubleML):
                   dml_procedure,
                   draw_sample_splitting,
                   apply_cross_fitting)
+        obj._check_data(obj._dml_data)
+        obj._check_score(obj.score)
         obj.partialX = True
         obj.partialZ = False
         _ = obj._check_learner(ml_g, 'ml_g', regressor=True, classifier=False)
@@ -168,6 +173,8 @@ class DoubleMLPLIV(DoubleML):
                   dml_procedure,
                   draw_sample_splitting,
                   apply_cross_fitting)
+        obj._check_data(obj._dml_data)
+        obj._check_score(obj.score)
         obj.partialX = False
         obj.partialZ = True
         _ = obj._check_learner(ml_r, 'ml_r', regressor=True, classifier=False)
@@ -198,6 +205,8 @@ class DoubleMLPLIV(DoubleML):
                   dml_procedure,
                   draw_sample_splitting,
                   apply_cross_fitting)
+        obj._check_data(obj._dml_data)
+        obj._check_score(obj.score)
         obj.partialX = True
         obj.partialZ = True
         _ = obj._check_learner(ml_g, 'ml_g', regressor=True, classifier=False)

--- a/doubleml/double_ml_plr.py
+++ b/doubleml/double_ml_plr.py
@@ -99,6 +99,8 @@ class DoubleMLPLR(DoubleML):
                          draw_sample_splitting,
                          apply_cross_fitting)
 
+        self._check_data(self._dml_data)
+        self._check_score(self.score)
         _ = self._check_learner(ml_g, 'ml_g', regressor=True, classifier=False)
         ml_m_is_classifier = self._check_learner(ml_m, 'ml_m', regressor=True, classifier=True)
         self._learner = {'ml_g': ml_g, 'ml_m': ml_m}
@@ -126,7 +128,7 @@ class DoubleMLPLR(DoubleML):
             if not callable(score):
                 raise TypeError('score should be either a string or a callable. '
                                 '%r was passed.' % score)
-        return score
+        return
 
     def _check_data(self, obj_dml_data):
         if obj_dml_data.z_cols is not None:


### PR DESCRIPTION
- This fixes two warnings raised by lgtm https://lgtm.com/projects/g/DoubleML/doubleml-for-py/alerts/?mode=list
- See https://lgtm.com/rules/10030085 for details on the warning
```
Calling a method from __init__ that is overridden by a subclass may result in a partially initialized instance being observed.
```