### PR TITLE
Improve exception handling for missings and infinite values in the confounders, predictions, etc.

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -37,6 +37,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.config.python-version }}
+    - name: Install OpenMP runtime for unit tests with xgboost learners
+      if: matrix.config.os == 'macOS-latest'
+      run: brew install libomp
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/doubleml/_utils.py
+++ b/doubleml/_utils.py
@@ -199,3 +199,10 @@ def _draw_weights(method, n_rep_boot, n_obs):
         raise ValueError('invalid boot method')
 
     return weights
+
+
+def _check_finite_predictions(preds, learner, learner_name, smpls):
+    test_indices = np.concatenate([test_index for _, test_index in smpls])
+    if not np.all(np.isfinite(preds[test_indices])):
+        raise ValueError(f'Predictions from learner {str(learner)} for {learner_name} are not finite.')
+    return

--- a/doubleml/double_ml_data.py
+++ b/doubleml/double_ml_data.py
@@ -39,6 +39,15 @@ class DoubleMLData:
         Indicates whether in the multiple-treatment case the other treatment variables should be added as covariates.
         Default is ``True``.
 
+    force_all_x_finite : bool or str
+        Indicates whether to raise an error on infinite values and / or missings in the covariates ``x``.
+        Possible values are: ``True`` (neither missings ``np.nan``, ``pd.NA`` nor infinite values ``np.inf`` are
+        allowed), ``False`` (missings and infinite values are allowed), ``'allow-nan'`` (only missings are allowed).
+        Note that the choice ``False`` and ``allow-nan`` are only reasonable if the machine learning methods used
+        for the nuisance functions are capable to provide valid predictions with missings and / or infinite values
+        in the covariates ``x``.
+        Default is ``True``.
+
     Examples
     --------
     >>> from doubleml import DoubleMLData
@@ -115,6 +124,15 @@ class DoubleMLData:
 
         use_other_treat_as_covariate : bool
             Indicates whether in the multiple-treatment case the other treatment variables should be added as covariates.
+            Default is ``True``.
+
+        force_all_x_finite : bool or str
+            Indicates whether to raise an error on infinite values and / or missings in the covariates ``x``.
+            Possible values are: ``True`` (neither missings ``np.nan``, ``pd.NA`` nor infinite values ``np.inf`` are
+            allowed), ``False`` (missings and infinite values are allowed), ``'allow-nan'`` (only missings are allowed).
+            Note that the choice ``False`` and ``allow-nan`` are only reasonable if the machine learning methods used
+            for the nuisance functions are capable to provide valid predictions with missings and / or infinite values
+            in the covariates ``x``.
             Default is ``True``.
 
         Examples
@@ -377,6 +395,28 @@ class DoubleMLData:
             # by default, we initialize to the first treatment variable
             self.set_x_d(self.d_cols[0])
 
+    @property
+    def force_all_x_finite(self):
+        """
+        Indicates whether to raise an error on infinite values and / or missings in the covariates ``x``.
+        """
+        return self._force_all_x_finite
+
+    @force_all_x_finite.setter
+    def force_all_x_finite(self, value):
+        reset_value = hasattr(self, '_force_all_x_finite')
+        if isinstance(value, str):
+            if value != 'allow-nan':
+                raise ValueError("Invalid force_all_x_finite " + value + ". " +
+                                 "force_all_x_finite must be True, False or 'allow-nan'.")
+        elif not isinstance(value, bool):
+            raise TypeError("Invalid force_all_x_finite." +
+                            "force_all_x_finite must be True, False or 'allow-nan'.")
+        self._force_all_x_finite = value
+        if reset_value:
+            # by default, we initialize to the first treatment variable
+            self.set_x_d(self.d_cols[0])
+
     def _set_y_z(self):
         assert_all_finite(self.data.loc[:, self.y_col])
         self._y = self.data.loc[:, self.y_col]
@@ -492,6 +532,15 @@ class DoubleMLClusterData(DoubleMLData):
         Indicates whether in the multiple-treatment case the other treatment variables should be added as covariates.
         Default is ``True``.
 
+    force_all_x_finite : bool or str
+        Indicates whether to raise an error on infinite values and / or missings in the covariates ``x``.
+        Possible values are: ``True`` (neither missings ``np.nan``, ``pd.NA`` nor infinite values ``np.inf`` are
+        allowed), ``False`` (missings and infinite values are allowed), ``'allow-nan'`` (only missings are allowed).
+        Note that the choice ``False`` and ``allow-nan`` are only reasonable if the machine learning methods used
+        for the nuisance functions are capable to provide valid predictions with missings and / or infinite values
+        in the covariates ``x``.
+        Default is ``True``.
+
     Examples
     --------
     >>> from doubleml import DoubleMLClusterData
@@ -572,6 +621,15 @@ class DoubleMLClusterData(DoubleMLData):
 
         use_other_treat_as_covariate : bool
             Indicates whether in the multiple-treatment case the other treatment variables should be added as covariates.
+            Default is ``True``.
+
+        force_all_x_finite : bool or str
+            Indicates whether to raise an error on infinite values and / or missings in the covariates ``x``.
+            Possible values are: ``True`` (neither missings ``np.nan``, ``pd.NA`` nor infinite values ``np.inf`` are
+            allowed), ``False`` (missings and infinite values are allowed), ``'allow-nan'`` (only missings are allowed).
+            Note that the choice ``False`` and ``allow-nan`` are only reasonable if the machine learning methods used
+            for the nuisance functions are capable to provide valid predictions with missings and / or infinite values
+            in the covariates ``x``.
             Default is ``True``.
 
         Examples

--- a/doubleml/double_ml_data.py
+++ b/doubleml/double_ml_data.py
@@ -506,7 +506,8 @@ class DoubleMLClusterData(DoubleMLData):
                  cluster_cols,
                  x_cols=None,
                  z_cols=None,
-                 use_other_treat_as_covariate=True):
+                 use_other_treat_as_covariate=True,
+                 force_all_x_finite=True):
         # we need to set cluster_cols (needs _data) before call to the super __init__ because of the x_cols setter
         if not isinstance(data, pd.DataFrame):
             raise TypeError('data must be of pd.DataFrame type. '
@@ -522,7 +523,8 @@ class DoubleMLClusterData(DoubleMLData):
                          d_cols,
                          x_cols,
                          z_cols,
-                         use_other_treat_as_covariate)
+                         use_other_treat_as_covariate,
+                         force_all_x_finite)
         self._check_disjoint_sets_cluster_cols()
 
     def __str__(self):
@@ -541,7 +543,8 @@ class DoubleMLClusterData(DoubleMLData):
         return res
 
     @classmethod
-    def from_arrays(cls, x, y, d, cluster_vars, z=None, use_other_treat_as_covariate=True):
+    def from_arrays(cls, x, y, d, cluster_vars, z=None, use_other_treat_as_covariate=True,
+                    force_all_x_finite=True):
         """
         Initialize :class:`DoubleMLClusterData` from :class:`numpy.ndarray`'s.
 
@@ -574,7 +577,7 @@ class DoubleMLClusterData(DoubleMLData):
         >>> (x, y, d, cluster_vars, z) = make_pliv_multiway_cluster_CKMS2021(return_type='array')
         >>> obj_dml_data_from_array = DoubleMLClusterData.from_arrays(x, y, d, cluster_vars, z)
         """
-        dml_data = DoubleMLData.from_arrays(x, y, d, z, use_other_treat_as_covariate)
+        dml_data = DoubleMLData.from_arrays(x, y, d, z, use_other_treat_as_covariate, force_all_x_finite)
         cluster_vars = check_array(cluster_vars, ensure_2d=False, allow_nd=False)
         cluster_vars = _assure_2d_array(cluster_vars)
         if cluster_vars.shape[1] == 1:
@@ -586,7 +589,8 @@ class DoubleMLClusterData(DoubleMLData):
 
         return(cls(data, dml_data.y_col, dml_data.d_cols,
                    cluster_cols,
-                   dml_data.x_cols, dml_data.z_cols, dml_data.use_other_treat_as_covariate))
+                   dml_data.x_cols, dml_data.z_cols,
+                   dml_data.use_other_treat_as_covariate, dml_data.force_all_x_finite))
 
     @property
     def cluster_cols(self):
@@ -675,4 +679,5 @@ class DoubleMLClusterData(DoubleMLData):
                                  'cluster variable in ``cluster_cols``.')
 
     def _set_cluster_vars(self):
+        assert_all_finite(self.data.loc[:, self.cluster_cols])
         self._cluster_vars = self.data.loc[:, self.cluster_cols]

--- a/doubleml/double_ml_data.py
+++ b/doubleml/double_ml_data.py
@@ -368,10 +368,14 @@ class DoubleMLData:
 
     @use_other_treat_as_covariate.setter
     def use_other_treat_as_covariate(self, value):
+        reset_value = hasattr(self, '_use_other_treat_as_covariate')
         if not isinstance(value, bool):
             raise TypeError('use_other_treat_as_covariate must be True or False. '
                             f'Got {str(value)}.')
         self._use_other_treat_as_covariate = value
+        if reset_value:
+            # by default, we initialize to the first treatment variable
+            self.set_x_d(self.d_cols[0])
 
     def _set_y_z(self):
         assert_all_finite(self.data.loc[:, self.y_col])

--- a/doubleml/double_ml_data.py
+++ b/doubleml/double_ml_data.py
@@ -124,7 +124,8 @@ class DoubleMLData:
         >>> (x, y, d) = make_plr_CCDDHNR2018(return_type='array')
         >>> obj_dml_data_from_array = DoubleMLData.from_arrays(x, y, d)
         """
-        x = check_array(x, ensure_2d=False, allow_nd=False)
+        x = check_array(x, ensure_2d=False, allow_nd=False,
+                        force_all_finite=force_all_x_finite)
         d = check_array(d, ensure_2d=False, allow_nd=False)
         y = column_or_1d(y, warn=True)
 

--- a/doubleml/double_ml_data.py
+++ b/doubleml/double_ml_data.py
@@ -3,7 +3,7 @@ import pandas as pd
 import io
 
 from sklearn.utils.validation import check_array, column_or_1d,  check_consistent_length
-from sklearn.utils import check_X_y, assert_all_finite
+from sklearn.utils import assert_all_finite
 from sklearn.utils.multiclass import type_of_target
 from ._utils import _assure_2d_array
 

--- a/doubleml/double_ml_data.py
+++ b/doubleml/double_ml_data.py
@@ -403,9 +403,12 @@ class DoubleMLData:
             xd_list.remove(treatment_var)
         else:
             xd_list = self.x_cols
-        self._d, self._X = check_X_y(self.data.loc[:, xd_list],
-                                     self.data.loc[:, treatment_var],
-                                     force_all_finite=self.force_all_x_finite)
+        assert_all_finite(self.data.loc[:, treatment_var])
+        if self.force_all_x_finite:
+            assert_all_finite(self.data.loc[:, xd_list],
+                              allow_nan=self.force_all_x_finite == 'allow-nan')
+        self._d = self.data.loc[:, treatment_var]
+        self._X = self.data.loc[:, xd_list]
 
     def _check_binary_treats(self):
         is_binary = pd.Series(dtype=bool, index=self.d_cols)

--- a/doubleml/double_ml_data.py
+++ b/doubleml/double_ml_data.py
@@ -43,7 +43,7 @@ class DoubleMLData:
         Indicates whether to raise an error on infinite values and / or missings in the covariates ``x``.
         Possible values are: ``True`` (neither missings ``np.nan``, ``pd.NA`` nor infinite values ``np.inf`` are
         allowed), ``False`` (missings and infinite values are allowed), ``'allow-nan'`` (only missings are allowed).
-        Note that the choice ``False`` and ``allow-nan`` are only reasonable if the machine learning methods used
+        Note that the choice ``False`` and ``'allow-nan'`` are only reasonable if the machine learning methods used
         for the nuisance functions are capable to provide valid predictions with missings and / or infinite values
         in the covariates ``x``.
         Default is ``True``.
@@ -130,7 +130,7 @@ class DoubleMLData:
             Indicates whether to raise an error on infinite values and / or missings in the covariates ``x``.
             Possible values are: ``True`` (neither missings ``np.nan``, ``pd.NA`` nor infinite values ``np.inf`` are
             allowed), ``False`` (missings and infinite values are allowed), ``'allow-nan'`` (only missings are allowed).
-            Note that the choice ``False`` and ``allow-nan`` are only reasonable if the machine learning methods used
+            Note that the choice ``False`` and ``'allow-nan'`` are only reasonable if the machine learning methods used
             for the nuisance functions are capable to provide valid predictions with missings and / or infinite values
             in the covariates ``x``.
             Default is ``True``.
@@ -544,7 +544,7 @@ class DoubleMLClusterData(DoubleMLData):
         Indicates whether to raise an error on infinite values and / or missings in the covariates ``x``.
         Possible values are: ``True`` (neither missings ``np.nan``, ``pd.NA`` nor infinite values ``np.inf`` are
         allowed), ``False`` (missings and infinite values are allowed), ``'allow-nan'`` (only missings are allowed).
-        Note that the choice ``False`` and ``allow-nan`` are only reasonable if the machine learning methods used
+        Note that the choice ``False`` and ``'allow-nan'`` are only reasonable if the machine learning methods used
         for the nuisance functions are capable to provide valid predictions with missings and / or infinite values
         in the covariates ``x``.
         Default is ``True``.
@@ -635,7 +635,7 @@ class DoubleMLClusterData(DoubleMLData):
             Indicates whether to raise an error on infinite values and / or missings in the covariates ``x``.
             Possible values are: ``True`` (neither missings ``np.nan``, ``pd.NA`` nor infinite values ``np.inf`` are
             allowed), ``False`` (missings and infinite values are allowed), ``'allow-nan'`` (only missings are allowed).
-            Note that the choice ``False`` and ``allow-nan`` are only reasonable if the machine learning methods used
+            Note that the choice ``False`` and ``'allow-nan'`` are only reasonable if the machine learning methods used
             for the nuisance functions are capable to provide valid predictions with missings and / or infinite values
             in the covariates ``x``.
             Default is ``True``.

--- a/doubleml/double_ml_data.py
+++ b/doubleml/double_ml_data.py
@@ -142,6 +142,14 @@ class DoubleMLData:
         >>> (x, y, d) = make_plr_CCDDHNR2018(return_type='array')
         >>> obj_dml_data_from_array = DoubleMLData.from_arrays(x, y, d)
         """
+        if isinstance(force_all_x_finite, str):
+            if force_all_x_finite != 'allow-nan':
+                raise ValueError("Invalid force_all_x_finite " + force_all_x_finite + ". " +
+                                 "force_all_x_finite must be True, False or 'allow-nan'.")
+        elif not isinstance(force_all_x_finite, bool):
+            raise TypeError("Invalid force_all_x_finite. " +
+                            "force_all_x_finite must be True, False or 'allow-nan'.")
+
         x = check_array(x, ensure_2d=False, allow_nd=False,
                         force_all_finite=force_all_x_finite)
         d = check_array(d, ensure_2d=False, allow_nd=False)
@@ -410,7 +418,7 @@ class DoubleMLData:
                 raise ValueError("Invalid force_all_x_finite " + value + ". " +
                                  "force_all_x_finite must be True, False or 'allow-nan'.")
         elif not isinstance(value, bool):
-            raise TypeError("Invalid force_all_x_finite." +
+            raise TypeError("Invalid force_all_x_finite. " +
                             "force_all_x_finite must be True, False or 'allow-nan'.")
         self._force_all_x_finite = value
         if reset_value:

--- a/doubleml/double_ml_iivm.py
+++ b/doubleml/double_ml_iivm.py
@@ -211,9 +211,12 @@ class DoubleMLIIVM(DoubleML):
         return
 
     def _ml_nuisance_and_score_elements(self, smpls, n_jobs_cv):
-        x, y = check_X_y(self._dml_data.x, self._dml_data.y)
-        x, z = check_X_y(x, np.ravel(self._dml_data.z))
-        x, d = check_X_y(x, self._dml_data.d)
+        x, y = check_X_y(self._dml_data.x, self._dml_data.y,
+                         force_all_finite=False)
+        x, z = check_X_y(x, np.ravel(self._dml_data.z),
+                         force_all_finite=False)
+        x, d = check_X_y(x, self._dml_data.d,
+                         force_all_finite=False)
 
         # get train indices for z == 0 and z == 1
         smpls_z0, smpls_z1 = _get_cond_smpls(smpls, z)
@@ -276,9 +279,12 @@ class DoubleMLIIVM(DoubleML):
 
     def _ml_nuisance_tuning(self, smpls, param_grids, scoring_methods, n_folds_tune, n_jobs_cv,
                             search_mode, n_iter_randomized_search):
-        x, y = check_X_y(self._dml_data.x, self._dml_data.y)
-        x, z = check_X_y(x, np.ravel(self._dml_data.z))
-        x, d = check_X_y(x, self._dml_data.d)
+        x, y = check_X_y(self._dml_data.x, self._dml_data.y,
+                         force_all_finite=False)
+        x, z = check_X_y(x, np.ravel(self._dml_data.z),
+                         force_all_finite=False)
+        x, d = check_X_y(x, self._dml_data.d,
+                         force_all_finite=False)
 
         # get train indices for z == 0 and z == 1
         smpls_z0, smpls_z1 = _get_cond_smpls(smpls, z)

--- a/doubleml/double_ml_iivm.py
+++ b/doubleml/double_ml_iivm.py
@@ -3,7 +3,7 @@ from sklearn.utils import check_X_y
 from sklearn.utils.multiclass import type_of_target
 
 from .double_ml import DoubleML
-from ._utils import _dml_cv_predict, _get_cond_smpls, _dml_tune
+from ._utils import _dml_cv_predict, _get_cond_smpls, _dml_tune, _check_finite_predictions
 
 
 class DoubleMLIIVM(DoubleML):
@@ -221,23 +221,18 @@ class DoubleMLIIVM(DoubleML):
         # get train indices for z == 0 and z == 1
         smpls_z0, smpls_z1 = _get_cond_smpls(smpls, z)
 
-        test_indices = np.concatenate([test_index for _, test_index in smpls])
-
         # nuisance g
         g_hat0 = _dml_cv_predict(self._learner['ml_g'], x, y, smpls=smpls_z0, n_jobs=n_jobs_cv,
                                  est_params=self._get_params('ml_g0'), method=self._predict_method['ml_g'])
-        if not np.all(np.isfinite(g_hat0[test_indices])):
-            raise ValueError(f'Prediction from learner {str(self._learner["ml_g"])} for ml_g are not finite.')
+        _check_finite_predictions(g_hat0, self._learner['ml_g'], 'ml_g', smpls)
         g_hat1 = _dml_cv_predict(self._learner['ml_g'], x, y, smpls=smpls_z1, n_jobs=n_jobs_cv,
                                  est_params=self._get_params('ml_g1'), method=self._predict_method['ml_g'])
-        if not np.all(np.isfinite(g_hat1[test_indices])):
-            raise ValueError(f'Prediction from learner {str(self._learner["ml_g"])} for ml_g are not finite.')
+        _check_finite_predictions(g_hat1, self._learner['ml_g'], 'ml_g', smpls)
 
         # nuisance m
         m_hat = _dml_cv_predict(self._learner['ml_m'], x, z, smpls=smpls, n_jobs=n_jobs_cv,
                                 est_params=self._get_params('ml_m'), method=self._predict_method['ml_m'])
-        if not np.all(np.isfinite(m_hat[test_indices])):
-            raise ValueError(f'Prediction from learner {str(self._learner["ml_m"])} for ml_m are not finite.')
+        _check_finite_predictions(m_hat, self._learner['ml_m'], 'ml_m', smpls)
 
         # nuisance r
         if self.subgroups['always_takers']:
@@ -245,16 +240,14 @@ class DoubleMLIIVM(DoubleML):
                                      est_params=self._get_params('ml_r0'), method=self._predict_method['ml_r'])
         else:
             r_hat0 = np.zeros_like(d)
-        if not np.all(np.isfinite(r_hat0[test_indices])):
-            raise ValueError(f'Prediction from learner {str(self._learner["ml_r"])} for ml_r are not finite.')
+        _check_finite_predictions(r_hat0, self._learner['ml_r'], 'ml_r', smpls)
 
         if self.subgroups['never_takers']:
             r_hat1 = _dml_cv_predict(self._learner['ml_r'], x, d, smpls=smpls_z1, n_jobs=n_jobs_cv,
                                      est_params=self._get_params('ml_r1'), method=self._predict_method['ml_r'])
         else:
             r_hat1 = np.ones_like(d)
-        if not np.all(np.isfinite(r_hat1[test_indices])):
-            raise ValueError(f'Prediction from learner {str(self._learner["ml_r"])} for ml_r are not finite.')
+        _check_finite_predictions(r_hat1, self._learner['ml_r'], 'ml_r', smpls)
 
         psi_a, psi_b = self._score_elements(y, z, d, g_hat0, g_hat1, m_hat, r_hat0, r_hat1, smpls)
         preds = {'ml_g0': g_hat0,

--- a/doubleml/double_ml_irm.py
+++ b/doubleml/double_ml_irm.py
@@ -171,17 +171,26 @@ class DoubleMLIRM(DoubleML):
         # get train indices for d == 0 and d == 1
         smpls_d0, smpls_d1 = _get_cond_smpls(smpls, d)
 
+        test_indices = np.concatenate([test_index for _, test_index in smpls])
+
         # nuisance g
         g_hat0 = _dml_cv_predict(self._learner['ml_g'], x, y, smpls=smpls_d0, n_jobs=n_jobs_cv,
                                  est_params=self._get_params('ml_g0'), method=self._predict_method['ml_g'])
+        if not np.all(np.isfinite(g_hat0[test_indices])):
+            raise ValueError(f'Prediction from learner {str(self._learner["ml_g"])} for ml_g are not finite.')
+
         g_hat1 = None
         if (self.score == 'ATE') | callable(self.score):
             g_hat1 = _dml_cv_predict(self._learner['ml_g'], x, y, smpls=smpls_d1, n_jobs=n_jobs_cv,
                                      est_params=self._get_params('ml_g1'), method=self._predict_method['ml_g'])
+            if not np.all(np.isfinite(g_hat1[test_indices])):
+                raise ValueError(f'Prediction from learner {str(self._learner["ml_g"])} for ml_g are not finite.')
 
         # nuisance m
         m_hat = _dml_cv_predict(self._learner['ml_m'], x, d, smpls=smpls, n_jobs=n_jobs_cv,
                                 est_params=self._get_params('ml_m'), method=self._predict_method['ml_m'])
+        if not np.all(np.isfinite(m_hat[test_indices])):
+            raise ValueError(f'Prediction from learner {str(self._learner["ml_m"])} for ml_m are not finite.')
 
         psi_a, psi_b = self._score_elements(y, d, g_hat0, g_hat1, m_hat, smpls)
         preds = {'ml_g0': g_hat0,

--- a/doubleml/double_ml_irm.py
+++ b/doubleml/double_ml_irm.py
@@ -164,8 +164,10 @@ class DoubleMLIRM(DoubleML):
         return
 
     def _ml_nuisance_and_score_elements(self, smpls, n_jobs_cv):
-        x, y = check_X_y(self._dml_data.x, self._dml_data.y)
-        x, d = check_X_y(x, self._dml_data.d)
+        x, y = check_X_y(self._dml_data.x, self._dml_data.y,
+                         force_all_finite=False)
+        x, d = check_X_y(x, self._dml_data.d,
+                         force_all_finite=False)
         # get train indices for d == 0 and d == 1
         smpls_d0, smpls_d1 = _get_cond_smpls(smpls, d)
 
@@ -226,8 +228,10 @@ class DoubleMLIRM(DoubleML):
 
     def _ml_nuisance_tuning(self, smpls, param_grids, scoring_methods, n_folds_tune, n_jobs_cv,
                             search_mode, n_iter_randomized_search):
-        x, y = check_X_y(self._dml_data.x, self._dml_data.y)
-        x, d = check_X_y(x, self._dml_data.d)
+        x, y = check_X_y(self._dml_data.x, self._dml_data.y,
+                         force_all_finite=False)
+        x, d = check_X_y(x, self._dml_data.d,
+                         force_all_finite=False)
         # get train indices for d == 0 and d == 1
         smpls_d0, smpls_d1 = _get_cond_smpls(smpls, d)
 

--- a/doubleml/double_ml_irm.py
+++ b/doubleml/double_ml_irm.py
@@ -3,7 +3,7 @@ from sklearn.utils import check_X_y
 from sklearn.utils.multiclass import type_of_target
 
 from .double_ml import DoubleML
-from ._utils import _dml_cv_predict, _get_cond_smpls, _dml_tune
+from ._utils import _dml_cv_predict, _get_cond_smpls, _dml_tune, _check_finite_predictions
 
 
 class DoubleMLIRM(DoubleML):
@@ -176,21 +176,18 @@ class DoubleMLIRM(DoubleML):
         # nuisance g
         g_hat0 = _dml_cv_predict(self._learner['ml_g'], x, y, smpls=smpls_d0, n_jobs=n_jobs_cv,
                                  est_params=self._get_params('ml_g0'), method=self._predict_method['ml_g'])
-        if not np.all(np.isfinite(g_hat0[test_indices])):
-            raise ValueError(f'Prediction from learner {str(self._learner["ml_g"])} for ml_g are not finite.')
+        _check_finite_predictions(g_hat0, self._learner['ml_g'], 'ml_g', smpls)
 
         g_hat1 = None
         if (self.score == 'ATE') | callable(self.score):
             g_hat1 = _dml_cv_predict(self._learner['ml_g'], x, y, smpls=smpls_d1, n_jobs=n_jobs_cv,
                                      est_params=self._get_params('ml_g1'), method=self._predict_method['ml_g'])
-            if not np.all(np.isfinite(g_hat1[test_indices])):
-                raise ValueError(f'Prediction from learner {str(self._learner["ml_g"])} for ml_g are not finite.')
+            _check_finite_predictions(g_hat1, self._learner['ml_g'], 'ml_g', smpls)
 
         # nuisance m
         m_hat = _dml_cv_predict(self._learner['ml_m'], x, d, smpls=smpls, n_jobs=n_jobs_cv,
                                 est_params=self._get_params('ml_m'), method=self._predict_method['ml_m'])
-        if not np.all(np.isfinite(m_hat[test_indices])):
-            raise ValueError(f'Prediction from learner {str(self._learner["ml_m"])} for ml_m are not finite.')
+        _check_finite_predictions(m_hat, self._learner['ml_m'], 'ml_m', smpls)
 
         psi_a, psi_b = self._score_elements(y, d, g_hat0, g_hat1, m_hat, smpls)
         preds = {'ml_g0': g_hat0,

--- a/doubleml/double_ml_irm.py
+++ b/doubleml/double_ml_irm.py
@@ -171,8 +171,6 @@ class DoubleMLIRM(DoubleML):
         # get train indices for d == 0 and d == 1
         smpls_d0, smpls_d1 = _get_cond_smpls(smpls, d)
 
-        test_indices = np.concatenate([test_index for _, test_index in smpls])
-
         # nuisance g
         g_hat0 = _dml_cv_predict(self._learner['ml_g'], x, y, smpls=smpls_d0, n_jobs=n_jobs_cv,
                                  est_params=self._get_params('ml_g0'), method=self._predict_method['ml_g'])

--- a/doubleml/double_ml_pliv.py
+++ b/doubleml/double_ml_pliv.py
@@ -287,9 +287,13 @@ class DoubleMLPLIV(DoubleML):
         x, d = check_X_y(x, self._dml_data.d,
                          force_all_finite=False)
 
+        test_indices = np.concatenate([test_index for _, test_index in smpls])
+
         # nuisance g
         g_hat = _dml_cv_predict(self._learner['ml_g'], x, y, smpls=smpls, n_jobs=n_jobs_cv,
                                 est_params=self._get_params('ml_g'), method=self._predict_method['ml_g'])
+        if not np.all(np.isfinite(g_hat[test_indices])):
+            raise ValueError(f'Prediction from learner {str(self._learner["ml_g"])} for ml_g are not finite.')
 
         # nuisance m
         if self._dml_data.n_instr == 1:
@@ -308,10 +312,14 @@ class DoubleMLPLIV(DoubleML):
                 m_hat[:, i_instr] = _dml_cv_predict(self._learner['ml_m'], x, this_z, smpls=smpls, n_jobs=n_jobs_cv,
                                                     est_params=self._get_params('ml_m_' + self._dml_data.z_cols[i_instr]),
                                                     method=self._predict_method['ml_m'])
+        if not np.all(np.isfinite(m_hat[test_indices])):
+            raise ValueError(f'Prediction from learner {str(self._learner["ml_m"])} for ml_m are not finite.')
 
         # nuisance r
         r_hat = _dml_cv_predict(self._learner['ml_r'], x, d, smpls=smpls, n_jobs=n_jobs_cv,
                                 est_params=self._get_params('ml_r'), method=self._predict_method['ml_r'])
+        if not np.all(np.isfinite(r_hat[test_indices])):
+            raise ValueError(f'Prediction from learner {str(self._learner["ml_r"])} for ml_r are not finite.')
 
         psi_a, psi_b = self._score_elements(y, z, d, g_hat, m_hat, r_hat, smpls)
         preds = {'ml_g': g_hat,
@@ -360,9 +368,13 @@ class DoubleMLPLIV(DoubleML):
                           self._dml_data.d,
                           force_all_finite=False)
 
+        test_indices = np.concatenate([test_index for _, test_index in smpls])
+
         # nuisance m
         r_hat = _dml_cv_predict(self._learner['ml_r'], xz, d, smpls=smpls, n_jobs=n_jobs_cv,
                                 est_params=self._get_params('ml_r'), method=self._predict_method['ml_r'])
+        if not np.all(np.isfinite(r_hat[test_indices])):
+            raise ValueError(f'Prediction from learner {str(self._learner["ml_r"])} for ml_r are not finite.')
 
         if isinstance(self.score, str):
             assert self.score == 'partialling out'
@@ -385,18 +397,28 @@ class DoubleMLPLIV(DoubleML):
         x, d = check_X_y(x, self._dml_data.d,
                          force_all_finite=False)
 
+        test_indices = np.concatenate([test_index for _, test_index in smpls])
+
         # nuisance g
         g_hat = _dml_cv_predict(self._learner['ml_g'], x, y, smpls=smpls, n_jobs=n_jobs_cv,
                                 est_params=self._get_params('ml_g'), method=self._predict_method['ml_g'])
+        if not np.all(np.isfinite(g_hat[test_indices])):
+            raise ValueError(f'Prediction from learner {str(self._learner["ml_g"])} for ml_g are not finite.')
 
         # nuisance m
         m_hat, m_hat_on_train = _dml_cv_predict(self._learner['ml_m'], xz, d, smpls=smpls, n_jobs=n_jobs_cv,
                                                 est_params=self._get_params('ml_m'), return_train_preds=True,
                                                 method=self._predict_method['ml_m'])
+        if not np.all(np.isfinite(m_hat[test_indices])):
+            raise ValueError(f'Prediction from learner {str(self._learner["ml_m"])} for ml_m are not finite.')
+        if not np.all(np.isfinite(m_hat_on_train[test_indices])):
+            raise ValueError(f'Prediction from learner {str(self._learner["ml_m"])} for ml_m are not finite.')
 
         # nuisance r
         m_hat_tilde = _dml_cv_predict(self._learner['ml_r'], x, m_hat_on_train, smpls=smpls, n_jobs=n_jobs_cv,
                                       est_params=self._get_params('ml_r'), method=self._predict_method['ml_r'])
+        if not np.all(np.isfinite(m_hat_tilde[test_indices])):
+            raise ValueError(f'Prediction from learner {str(self._learner["ml_r"])} for ml_r are not finite.')
 
         # compute residuals
         u_hat = y - g_hat

--- a/doubleml/double_ml_pliv.py
+++ b/doubleml/double_ml_pliv.py
@@ -6,7 +6,7 @@ from sklearn.linear_model import LinearRegression
 from sklearn.dummy import DummyRegressor
 
 from .double_ml import DoubleML
-from ._utils import _dml_cv_predict, _dml_tune
+from ._utils import _dml_cv_predict, _dml_tune, _check_finite_predictions
 
 
 class DoubleMLPLIV(DoubleML):
@@ -287,13 +287,10 @@ class DoubleMLPLIV(DoubleML):
         x, d = check_X_y(x, self._dml_data.d,
                          force_all_finite=False)
 
-        test_indices = np.concatenate([test_index for _, test_index in smpls])
-
         # nuisance g
         g_hat = _dml_cv_predict(self._learner['ml_g'], x, y, smpls=smpls, n_jobs=n_jobs_cv,
                                 est_params=self._get_params('ml_g'), method=self._predict_method['ml_g'])
-        if not np.all(np.isfinite(g_hat[test_indices])):
-            raise ValueError(f'Prediction from learner {str(self._learner["ml_g"])} for ml_g are not finite.')
+        _check_finite_predictions(g_hat, self._learner['ml_g'], 'ml_g', smpls)
 
         # nuisance m
         if self._dml_data.n_instr == 1:
@@ -312,14 +309,12 @@ class DoubleMLPLIV(DoubleML):
                 m_hat[:, i_instr] = _dml_cv_predict(self._learner['ml_m'], x, this_z, smpls=smpls, n_jobs=n_jobs_cv,
                                                     est_params=self._get_params('ml_m_' + self._dml_data.z_cols[i_instr]),
                                                     method=self._predict_method['ml_m'])
-        if not np.all(np.isfinite(m_hat[test_indices])):
-            raise ValueError(f'Prediction from learner {str(self._learner["ml_m"])} for ml_m are not finite.')
+        _check_finite_predictions(m_hat, self._learner['ml_m'], 'ml_m', smpls)
 
         # nuisance r
         r_hat = _dml_cv_predict(self._learner['ml_r'], x, d, smpls=smpls, n_jobs=n_jobs_cv,
                                 est_params=self._get_params('ml_r'), method=self._predict_method['ml_r'])
-        if not np.all(np.isfinite(r_hat[test_indices])):
-            raise ValueError(f'Prediction from learner {str(self._learner["ml_r"])} for ml_r are not finite.')
+        _check_finite_predictions(r_hat, self._learner['ml_r'], 'ml_r', smpls)
 
         psi_a, psi_b = self._score_elements(y, z, d, g_hat, m_hat, r_hat, smpls)
         preds = {'ml_g': g_hat,
@@ -368,13 +363,10 @@ class DoubleMLPLIV(DoubleML):
                           self._dml_data.d,
                           force_all_finite=False)
 
-        test_indices = np.concatenate([test_index for _, test_index in smpls])
-
         # nuisance m
         r_hat = _dml_cv_predict(self._learner['ml_r'], xz, d, smpls=smpls, n_jobs=n_jobs_cv,
                                 est_params=self._get_params('ml_r'), method=self._predict_method['ml_r'])
-        if not np.all(np.isfinite(r_hat[test_indices])):
-            raise ValueError(f'Prediction from learner {str(self._learner["ml_r"])} for ml_r are not finite.')
+        _check_finite_predictions(r_hat, self._learner['ml_r'], 'ml_r', smpls)
 
         if isinstance(self.score, str):
             assert self.score == 'partialling out'
@@ -397,28 +389,21 @@ class DoubleMLPLIV(DoubleML):
         x, d = check_X_y(x, self._dml_data.d,
                          force_all_finite=False)
 
-        test_indices = np.concatenate([test_index for _, test_index in smpls])
-
         # nuisance g
         g_hat = _dml_cv_predict(self._learner['ml_g'], x, y, smpls=smpls, n_jobs=n_jobs_cv,
                                 est_params=self._get_params('ml_g'), method=self._predict_method['ml_g'])
-        if not np.all(np.isfinite(g_hat[test_indices])):
-            raise ValueError(f'Prediction from learner {str(self._learner["ml_g"])} for ml_g are not finite.')
+        _check_finite_predictions(g_hat, self._learner['ml_g'], 'ml_g', smpls)
 
         # nuisance m
         m_hat, m_hat_on_train = _dml_cv_predict(self._learner['ml_m'], xz, d, smpls=smpls, n_jobs=n_jobs_cv,
                                                 est_params=self._get_params('ml_m'), return_train_preds=True,
                                                 method=self._predict_method['ml_m'])
-        if not np.all(np.isfinite(m_hat[test_indices])):
-            raise ValueError(f'Prediction from learner {str(self._learner["ml_m"])} for ml_m are not finite.')
-        if not np.all(np.isfinite(m_hat_on_train[test_indices])):
-            raise ValueError(f'Prediction from learner {str(self._learner["ml_m"])} for ml_m are not finite.')
+        _check_finite_predictions(m_hat, self._learner['ml_m'], 'ml_m', smpls)
 
         # nuisance r
         m_hat_tilde = _dml_cv_predict(self._learner['ml_r'], x, m_hat_on_train, smpls=smpls, n_jobs=n_jobs_cv,
                                       est_params=self._get_params('ml_r'), method=self._predict_method['ml_r'])
-        if not np.all(np.isfinite(m_hat_tilde[test_indices])):
-            raise ValueError(f'Prediction from learner {str(self._learner["ml_r"])} for ml_r are not finite.')
+        _check_finite_predictions(m_hat_tilde, self._learner['ml_r'], 'ml_r', smpls)
 
         # compute residuals
         u_hat = y - g_hat

--- a/doubleml/double_ml_pliv.py
+++ b/doubleml/double_ml_pliv.py
@@ -282,8 +282,10 @@ class DoubleMLPLIV(DoubleML):
         return res
 
     def _ml_nuisance_and_score_elements_partial_x(self, smpls, n_jobs_cv):
-        x, y = check_X_y(self._dml_data.x, self._dml_data.y)
-        x, d = check_X_y(x, self._dml_data.d)
+        x, y = check_X_y(self._dml_data.x, self._dml_data.y,
+                         force_all_finite=False)
+        x, d = check_X_y(x, self._dml_data.d,
+                         force_all_finite=False)
 
         # nuisance g
         g_hat = _dml_cv_predict(self._learner['ml_g'], x, y, smpls=smpls, n_jobs=n_jobs_cv,
@@ -292,7 +294,8 @@ class DoubleMLPLIV(DoubleML):
         # nuisance m
         if self._dml_data.n_instr == 1:
             # one instrument: just identified
-            x, z = check_X_y(x, np.ravel(self._dml_data.z))
+            x, z = check_X_y(x, np.ravel(self._dml_data.z),
+                             force_all_finite=False)
             m_hat = _dml_cv_predict(self._learner['ml_m'], x, z, smpls=smpls, n_jobs=n_jobs_cv,
                                     est_params=self._get_params('ml_m'), method=self._predict_method['ml_m'])
         else:
@@ -300,7 +303,8 @@ class DoubleMLPLIV(DoubleML):
             m_hat = np.full((self._dml_data.n_obs, self._dml_data.n_instr), np.nan)
             z = self._dml_data.z
             for i_instr in range(self._dml_data.n_instr):
-                x, this_z = check_X_y(x, z[:, i_instr])
+                x, this_z = check_X_y(x, z[:, i_instr],
+                                      force_all_finite=False)
                 m_hat[:, i_instr] = _dml_cv_predict(self._learner['ml_m'], x, this_z, smpls=smpls, n_jobs=n_jobs_cv,
                                                     est_params=self._get_params('ml_m_' + self._dml_data.z_cols[i_instr]),
                                                     method=self._predict_method['ml_m'])
@@ -353,7 +357,8 @@ class DoubleMLPLIV(DoubleML):
     def _ml_nuisance_and_score_elements_partial_z(self, smpls, n_jobs_cv):
         y = self._dml_data.y
         xz, d = check_X_y(np.hstack((self._dml_data.x, self._dml_data.z)),
-                          self._dml_data.d)
+                          self._dml_data.d,
+                          force_all_finite=False)
 
         # nuisance m
         r_hat = _dml_cv_predict(self._learner['ml_r'], xz, d, smpls=smpls, n_jobs=n_jobs_cv,
@@ -372,10 +377,13 @@ class DoubleMLPLIV(DoubleML):
         return psi_a, psi_b, preds
 
     def _ml_nuisance_and_score_elements_partial_xz(self, smpls, n_jobs_cv):
-        x, y = check_X_y(self._dml_data.x, self._dml_data.y)
+        x, y = check_X_y(self._dml_data.x, self._dml_data.y,
+                         force_all_finite=False)
         xz, d = check_X_y(np.hstack((self._dml_data.x, self._dml_data.z)),
-                          self._dml_data.d)
-        x, d = check_X_y(x, self._dml_data.d)
+                          self._dml_data.d,
+                          force_all_finite=False)
+        x, d = check_X_y(x, self._dml_data.d,
+                         force_all_finite=False)
 
         # nuisance g
         g_hat = _dml_cv_predict(self._learner['ml_g'], x, y, smpls=smpls, n_jobs=n_jobs_cv,
@@ -410,8 +418,10 @@ class DoubleMLPLIV(DoubleML):
 
     def _ml_nuisance_tuning_partial_x(self, smpls, param_grids, scoring_methods, n_folds_tune, n_jobs_cv,
                                       search_mode, n_iter_randomized_search):
-        x, y = check_X_y(self._dml_data.x, self._dml_data.y)
-        x, d = check_X_y(x, self._dml_data.d)
+        x, y = check_X_y(self._dml_data.x, self._dml_data.y,
+                         force_all_finite=False)
+        x, d = check_X_y(x, self._dml_data.d,
+                         force_all_finite=False)
 
         if scoring_methods is None:
             scoring_methods = {'ml_g': None,
@@ -428,7 +438,8 @@ class DoubleMLPLIV(DoubleML):
             m_tune_res = {instr_var: list() for instr_var in self._dml_data.z_cols}
             z = self._dml_data.z
             for i_instr in range(self._dml_data.n_instr):
-                x, this_z = check_X_y(x, z[:, i_instr])
+                x, this_z = check_X_y(x, z[:, i_instr],
+                                      force_all_finite=False)
                 m_tune_res[self._dml_data.z_cols[i_instr]] = _dml_tune(this_z, x, train_inds,
                                                                        self._learner['ml_m'], param_grids['ml_m'],
                                                                        scoring_methods['ml_m'],
@@ -436,7 +447,8 @@ class DoubleMLPLIV(DoubleML):
                                                                        n_iter_randomized_search)
         else:
             # one instrument: just identified
-            x, z = check_X_y(x, np.ravel(self._dml_data.z))
+            x, z = check_X_y(x, np.ravel(self._dml_data.z),
+                             force_all_finite=False)
             m_tune_res = _dml_tune(z, x, train_inds,
                                    self._learner['ml_m'], param_grids['ml_m'], scoring_methods['ml_m'],
                                    n_folds_tune, n_jobs_cv, search_mode, n_iter_randomized_search)
@@ -470,7 +482,8 @@ class DoubleMLPLIV(DoubleML):
     def _ml_nuisance_tuning_partial_z(self, smpls, param_grids, scoring_methods, n_folds_tune, n_jobs_cv,
                                       search_mode, n_iter_randomized_search):
         xz, d = check_X_y(np.hstack((self._dml_data.x, self._dml_data.z)),
-                          self._dml_data.d)
+                          self._dml_data.d,
+                          force_all_finite=False)
 
         if scoring_methods is None:
             scoring_methods = {'ml_r': None}
@@ -493,10 +506,13 @@ class DoubleMLPLIV(DoubleML):
 
     def _ml_nuisance_tuning_partial_xz(self, smpls, param_grids, scoring_methods, n_folds_tune, n_jobs_cv,
                                        search_mode, n_iter_randomized_search):
-        x, y = check_X_y(self._dml_data.x, self._dml_data.y)
+        x, y = check_X_y(self._dml_data.x, self._dml_data.y,
+                         force_all_finite=False)
         xz, d = check_X_y(np.hstack((self._dml_data.x, self._dml_data.z)),
-                          self._dml_data.d)
-        x, d = check_X_y(x, self._dml_data.d)
+                          self._dml_data.d,
+                          force_all_finite=False)
+        x, d = check_X_y(x, self._dml_data.d,
+                         force_all_finite=False)
 
         if scoring_methods is None:
             scoring_methods = {'ml_g': None,

--- a/doubleml/double_ml_plr.py
+++ b/doubleml/double_ml_plr.py
@@ -144,13 +144,19 @@ class DoubleMLPLR(DoubleML):
         x, d = check_X_y(x, self._dml_data.d,
                          force_all_finite=False)
 
+        test_indices = np.concatenate([test_index for _, test_index in smpls])
+
         # nuisance g
         g_hat = _dml_cv_predict(self._learner['ml_g'], x, y, smpls=smpls, n_jobs=n_jobs_cv,
                                 est_params=self._get_params('ml_g'), method=self._predict_method['ml_g'])
+        if not np.all(np.isfinite(g_hat[test_indices])):
+            raise ValueError(f'Prediction from learner {str(self._learner["ml_g"])} for ml_g are not finite.')
 
         # nuisance m
         m_hat = _dml_cv_predict(self._learner['ml_m'], x, d, smpls=smpls, n_jobs=n_jobs_cv,
                                 est_params=self._get_params('ml_m'), method=self._predict_method['ml_m'])
+        if not np.all(np.isfinite(m_hat[test_indices])):
+            raise ValueError(f'Prediction from learner {str(self._learner["ml_m"])} for ml_m are not finite.')
 
         if self._dml_data.binary_treats[self._dml_data.d_cols[self._i_treat]]:
             binary_preds = (type_of_target(m_hat) == 'binary')

--- a/doubleml/double_ml_plr.py
+++ b/doubleml/double_ml_plr.py
@@ -139,8 +139,10 @@ class DoubleMLPLR(DoubleML):
         return
 
     def _ml_nuisance_and_score_elements(self, smpls, n_jobs_cv):
-        x, y = check_X_y(self._dml_data.x, self._dml_data.y)
-        x, d = check_X_y(x, self._dml_data.d)
+        x, y = check_X_y(self._dml_data.x, self._dml_data.y,
+                         force_all_finite=False)
+        x, d = check_X_y(x, self._dml_data.d,
+                         force_all_finite=False)
 
         # nuisance g
         g_hat = _dml_cv_predict(self._learner['ml_g'], x, y, smpls=smpls, n_jobs=n_jobs_cv,
@@ -186,8 +188,10 @@ class DoubleMLPLR(DoubleML):
 
     def _ml_nuisance_tuning(self, smpls, param_grids, scoring_methods, n_folds_tune, n_jobs_cv,
                             search_mode, n_iter_randomized_search):
-        x, y = check_X_y(self._dml_data.x, self._dml_data.y)
-        x, d = check_X_y(x, self._dml_data.d)
+        x, y = check_X_y(self._dml_data.x, self._dml_data.y,
+                         force_all_finite=False)
+        x, d = check_X_y(x, self._dml_data.d,
+                         force_all_finite=False)
 
         if scoring_methods is None:
             scoring_methods = {'ml_g': None,

--- a/doubleml/double_ml_plr.py
+++ b/doubleml/double_ml_plr.py
@@ -3,7 +3,7 @@ from sklearn.utils import check_X_y
 from sklearn.utils.multiclass import type_of_target
 
 from .double_ml import DoubleML
-from ._utils import _dml_cv_predict, _dml_tune
+from ._utils import _dml_cv_predict, _dml_tune, _check_finite_predictions
 
 
 class DoubleMLPLR(DoubleML):
@@ -144,19 +144,15 @@ class DoubleMLPLR(DoubleML):
         x, d = check_X_y(x, self._dml_data.d,
                          force_all_finite=False)
 
-        test_indices = np.concatenate([test_index for _, test_index in smpls])
-
         # nuisance g
         g_hat = _dml_cv_predict(self._learner['ml_g'], x, y, smpls=smpls, n_jobs=n_jobs_cv,
                                 est_params=self._get_params('ml_g'), method=self._predict_method['ml_g'])
-        if not np.all(np.isfinite(g_hat[test_indices])):
-            raise ValueError(f'Prediction from learner {str(self._learner["ml_g"])} for ml_g are not finite.')
+        _check_finite_predictions(g_hat, self._learner['ml_g'], 'ml_g', smpls)
 
         # nuisance m
         m_hat = _dml_cv_predict(self._learner['ml_m'], x, d, smpls=smpls, n_jobs=n_jobs_cv,
                                 est_params=self._get_params('ml_m'), method=self._predict_method['ml_m'])
-        if not np.all(np.isfinite(m_hat[test_indices])):
-            raise ValueError(f'Prediction from learner {str(self._learner["ml_m"])} for ml_m are not finite.')
+        _check_finite_predictions(m_hat, self._learner['ml_m'], 'ml_m', smpls)
 
         if self._dml_data.binary_treats[self._dml_data.d_cols[self._i_treat]]:
             binary_preds = (type_of_target(m_hat) == 'binary')

--- a/doubleml/tests/conftest.py
+++ b/doubleml/tests/conftest.py
@@ -284,8 +284,8 @@ def generate_data_irm_w_missings(request):
 
     # randomly set some entries to np.nan
     ind = np.random.choice(np.arange(x.size), replace=False,
-                           size=int(x.size * 0.2))
-    x[ind] = np.nan
+                           size=int(x.size * 0.05))
+    x[np.unravel_index(ind, x.shape)] = np.nan
     data = (x, y, d)
 
     return data

--- a/doubleml/tests/conftest.py
+++ b/doubleml/tests/conftest.py
@@ -266,3 +266,26 @@ def generate_data_cv_predict(request):
     data = (x, y, classifier)
 
     return data
+
+
+@pytest.fixture(scope='session',
+                params=[(500, 10),
+                        (1000, 20)])
+def generate_data_irm_w_missings(request):
+    n_p = request.param
+    np.random.seed(1111)
+    # setting parameters
+    n = n_p[0]
+    p = n_p[1]
+    theta = 0.5
+
+    # generating data
+    (x, y, d) = make_irm_data(n, p, theta, return_type='array')
+
+    # randomly set some entries to np.nan
+    ind = np.random.choice(np.arange(x.size), replace=False,
+                           size=int(x.size * 0.2))
+    x[ind] = np.nan
+    data = (x, y, d)
+
+    return data

--- a/doubleml/tests/test_dml_data.py
+++ b/doubleml/tests/test_dml_data.py
@@ -456,8 +456,8 @@ def test_dml_datatype():
 def test_dml_data_w_missings(generate_data_irm_w_missings):
     (x, y, d) = generate_data_irm_w_missings
 
-    _ = DoubleMLData.from_arrays(x, y, d,
-                                 force_all_x_finite=False)
+    dml_data = DoubleMLData.from_arrays(x, y, d,
+                                        force_all_x_finite=False)
 
     _ = DoubleMLData.from_arrays(x, y, d,
                                  force_all_x_finite='allow-nan')
@@ -485,3 +485,22 @@ def test_dml_data_w_missings(generate_data_irm_w_missings):
     with pytest.raises(ValueError, match=msg):
         _ = DoubleMLData.from_arrays(xx, y, d,
                                      force_all_x_finite='allow-nan')
+
+    msg = "Invalid force_all_x_finite. force_all_x_finite must be True, False or 'allow-nan'."
+    with pytest.raises(TypeError, match=msg):
+        _ = DoubleMLData.from_arrays(xx, y, d,
+                                     force_all_x_finite=1)
+    with pytest.raises(TypeError, match=msg):
+        _ = DoubleMLData(dml_data.data,
+                         y_col='y', d_cols='d',
+                         force_all_x_finite=1)
+
+    msg = r"Input contains NaN, infinity or a value too large for dtype\('float64'\)."
+    with pytest.raises(ValueError, match=msg):
+        dml_data.force_all_x_finite = True
+
+    assert dml_data.force_all_x_finite is True
+    dml_data.force_all_x_finite = False
+    assert dml_data.force_all_x_finite is False
+    dml_data.force_all_x_finite = 'allow-nan'
+    assert dml_data.force_all_x_finite == 'allow-nan'

--- a/doubleml/tests/test_dml_data.py
+++ b/doubleml/tests/test_dml_data.py
@@ -338,6 +338,10 @@ def test_use_other_treat_as_covariate():
     assert np.array_equal(dml_data.d, df['d2'].values)
     assert np.array_equal(dml_data.x, df[[f'X{i + 1}' for i in np.arange(7)]].values)
 
+    dml_data.use_other_treat_as_covariate = True
+    assert np.array_equal(dml_data.d, df['d1'].values)
+    assert np.array_equal(dml_data.x, df[[f'X{i + 1}' for i in np.arange(7)] + ['d2']].values)
+
     msg = 'use_other_treat_as_covariate must be True or False. Got 1.'
     with pytest.raises(TypeError, match=msg):
         _ = DoubleMLData(df, 'y', ['d1', 'd2'], [f'X{i + 1}' for i in np.arange(7)],

--- a/doubleml/tests/test_dml_data.py
+++ b/doubleml/tests/test_dml_data.py
@@ -495,6 +495,15 @@ def test_dml_data_w_missings(generate_data_irm_w_missings):
                          y_col='y', d_cols='d',
                          force_all_x_finite=1)
 
+    msg = "Invalid force_all_x_finite allownan. force_all_x_finite must be True, False or 'allow-nan'."
+    with pytest.raises(ValueError, match=msg):
+        _ = DoubleMLData.from_arrays(xx, y, d,
+                                     force_all_x_finite='allownan')
+    with pytest.raises(ValueError, match=msg):
+        _ = DoubleMLData(dml_data.data,
+                         y_col='y', d_cols='d',
+                         force_all_x_finite='allownan')
+
     msg = r"Input contains NaN, infinity or a value too large for dtype\('float64'\)."
     with pytest.raises(ValueError, match=msg):
         dml_data.force_all_x_finite = True

--- a/doubleml/tests/test_dml_data.py
+++ b/doubleml/tests/test_dml_data.py
@@ -446,3 +446,38 @@ def test_dml_datatype():
         _ = DoubleMLData(data_array, y_col='y', d_cols=['d'], x_cols=['X3', 'X2'])
     with pytest.raises(TypeError):
         _ = DoubleMLClusterData(data_array, y_col='y', d_cols=['d'], cluster_cols=['X3', 'X2'])
+
+
+@pytest.mark.ci
+def test_dml_data_w_missings(generate_data_irm_w_missings):
+    (x, y, d) = generate_data_irm_w_missings
+
+    _ = DoubleMLData.from_arrays(x, y, d,
+                                 force_all_x_finite=False)
+
+    _ = DoubleMLData.from_arrays(x, y, d,
+                                 force_all_x_finite='allow-nan')
+
+    msg = r"Input contains NaN, infinity or a value too large for dtype\('float64'\)."
+    with pytest.raises(ValueError, match=msg):
+        _ = DoubleMLData.from_arrays(x, y, d,
+                                     force_all_x_finite=True)
+
+    with pytest.raises(ValueError, match=msg):
+        _ = DoubleMLData.from_arrays(x, x[:, 0], d,
+                                     force_all_x_finite=False)
+
+    with pytest.raises(ValueError, match=msg):
+        _ = DoubleMLData.from_arrays(x, y, x[:, 0],
+                                     force_all_x_finite=False)
+
+    with pytest.raises(ValueError, match=msg):
+        _ = DoubleMLData.from_arrays(x, y, d, x[:, 0],
+                                     force_all_x_finite=False)
+
+    msg = r"Input contains infinity or a value too large for dtype\('float64'\)."
+    xx = x
+    xx[0, 0] = np.inf
+    with pytest.raises(ValueError, match=msg):
+        _ = DoubleMLData.from_arrays(xx, y, d,
+                                     force_all_x_finite='allow-nan')

--- a/doubleml/tests/test_dml_data.py
+++ b/doubleml/tests/test_dml_data.py
@@ -480,7 +480,7 @@ def test_dml_data_w_missings(generate_data_irm_w_missings):
                                      force_all_x_finite=False)
 
     msg = r"Input contains infinity or a value too large for dtype\('float64'\)."
-    xx = x
+    xx = np.copy(x)
     xx[0, 0] = np.inf
     with pytest.raises(ValueError, match=msg):
         _ = DoubleMLData.from_arrays(xx, y, d,

--- a/doubleml/tests/test_doubleml_exceptions.py
+++ b/doubleml/tests/test_doubleml_exceptions.py
@@ -508,16 +508,16 @@ class LassoWithInfPred(Lasso):
 @pytest.mark.ci
 def test_doubleml_nan_prediction():
 
-    msg = r'Prediction from learner LassoWithNanPred\(\) for ml_g are not finite.'
+    msg = r'Predictions from learner LassoWithNanPred\(\) for ml_g are not finite.'
     with pytest.raises(ValueError, match=msg):
         _ = DoubleMLPLR(dml_data, LassoWithNanPred(), ml_m).fit()
-    msg = r'Prediction from learner LassoWithInfPred\(\) for ml_g are not finite.'
+    msg = r'Predictions from learner LassoWithInfPred\(\) for ml_g are not finite.'
     with pytest.raises(ValueError, match=msg):
         _ = DoubleMLPLR(dml_data, LassoWithInfPred(), ml_m).fit()
 
-    msg = r'Prediction from learner LassoWithNanPred\(\) for ml_m are not finite.'
+    msg = r'Predictions from learner LassoWithNanPred\(\) for ml_m are not finite.'
     with pytest.raises(ValueError, match=msg):
         _ = DoubleMLPLR(dml_data, ml_g, LassoWithNanPred()).fit()
-    msg = r'Prediction from learner LassoWithInfPred\(\) for ml_m are not finite.'
+    msg = r'Predictions from learner LassoWithInfPred\(\) for ml_m are not finite.'
     with pytest.raises(ValueError, match=msg):
         _ = DoubleMLPLR(dml_data, ml_g, LassoWithInfPred()).fit()

--- a/doubleml/tests/test_doubleml_exceptions.py
+++ b/doubleml/tests/test_doubleml_exceptions.py
@@ -487,3 +487,37 @@ def test_doubleml_cluster_not_yet_implemented():
     with pytest.raises(NotImplementedError, match=msg):
         _ = DoubleMLPLIV(dml_cluster_data_pliv, ml_g, ml_m, ml_r,
                          apply_cross_fitting=False, n_folds=2)
+
+
+class LassoWithNanPred(Lasso):
+    def predict(self, X):
+        preds = super(Lasso, self).predict(X)
+        n_obs = len(preds)
+        preds[np.random.randint(0, n_obs, 2)] = np.nan
+        return preds
+
+
+class LassoWithInfPred(Lasso):
+    def predict(self, X):
+        preds = super(Lasso, self).predict(X)
+        n_obs = len(preds)
+        preds[np.random.randint(0, n_obs, 2)] = np.inf
+        return preds
+
+
+@pytest.mark.ci
+def test_doubleml_nan_prediction():
+
+    msg = r'Prediction from learner LassoWithNanPred\(\) for ml_g are not finite.'
+    with pytest.raises(ValueError, match=msg):
+        _ = DoubleMLPLR(dml_data, LassoWithNanPred(), ml_m).fit()
+    msg = r'Prediction from learner LassoWithInfPred\(\) for ml_g are not finite.'
+    with pytest.raises(ValueError, match=msg):
+        _ = DoubleMLPLR(dml_data, LassoWithInfPred(), ml_m).fit()
+
+    msg = r'Prediction from learner LassoWithNanPred\(\) for ml_m are not finite.'
+    with pytest.raises(ValueError, match=msg):
+        _ = DoubleMLPLR(dml_data, ml_g, LassoWithNanPred()).fit()
+    msg = r'Prediction from learner LassoWithInfPred\(\) for ml_m are not finite.'
+    with pytest.raises(ValueError, match=msg):
+        _ = DoubleMLPLR(dml_data, ml_g, LassoWithInfPred()).fit()

--- a/doubleml/tests/test_doubleml_exceptions.py
+++ b/doubleml/tests/test_doubleml_exceptions.py
@@ -491,17 +491,17 @@ def test_doubleml_cluster_not_yet_implemented():
 
 class LassoWithNanPred(Lasso):
     def predict(self, X):
-        preds = super(Lasso, self).predict(X)
+        preds = super().predict(X)
         n_obs = len(preds)
-        preds[np.random.randint(0, n_obs, 2)] = np.nan
+        preds[np.random.randint(0, n_obs, 1)] = np.nan
         return preds
 
 
 class LassoWithInfPred(Lasso):
     def predict(self, X):
-        preds = super(Lasso, self).predict(X)
+        preds = super().predict(X)
         n_obs = len(preds)
-        preds[np.random.randint(0, n_obs, 2)] = np.inf
+        preds[np.random.randint(0, n_obs, 1)] = np.inf
         return preds
 
 

--- a/doubleml/tests/test_irm_with_missings.py
+++ b/doubleml/tests/test_irm_with_missings.py
@@ -1,0 +1,149 @@
+import numpy as np
+import pytest
+import math
+
+from sklearn.base import clone
+
+# TODO: Maybe add some learner which cannot handle missings in x and test the exception
+from sklearn.linear_model import LogisticRegression, LinearRegression
+from xgboost import XGBClassifier, XGBRegressor
+
+import doubleml as dml
+
+from ._utils import draw_smpls
+from ._utils_irm_manual import fit_irm, boot_irm
+
+
+@pytest.fixture(scope='module',
+                params=[[XGBRegressor(n_jobs=1, objective="reg:squarederror",
+                                      eta=0.1, n_estimators=10),
+                         XGBClassifier(use_label_encoder=False, n_jobs=1,
+                                       objective="binary:logistic", eval_metric="logloss",
+                                       eta=0.1, n_estimators=10)]])
+def learner_xgboost(request):
+    return request.param
+
+
+@pytest.fixture(scope='module',
+                params=[[LinearRegression(),
+                         LogisticRegression(solver='lbfgs', max_iter=250)]])
+def learner_sklearn(request):
+    return request.param
+
+
+@pytest.fixture(scope='module',
+                params=['ATE', 'ATTE'])
+def score(request):
+    return request.param
+
+
+@pytest.fixture(scope='module',
+                params=['dml1', 'dml2'])
+def dml_procedure(request):
+    return request.param
+
+
+@pytest.fixture(scope='module',
+                params=[0.01, 0.05])
+def trimming_threshold(request):
+    return request.param
+
+
+@pytest.fixture(scope='module')
+def dml_irm_fixture(generate_data_irm_w_missings, learner_xgboost, score, dml_procedure, trimming_threshold):
+    boot_methods = ['normal']
+    n_folds = 2
+    n_rep_boot = 499
+
+    # collect data
+    (x, y, d) = generate_data_irm_w_missings
+
+    # Set machine learning methods for m & g
+    ml_g = clone(learner_xgboost[0])
+    ml_m = clone(learner_xgboost[1])
+
+    np.random.seed(3141)
+    obj_dml_data = dml.DoubleMLData.from_arrays(x, y, d,
+                                                force_all_x_finite=False)
+    dml_irm_obj = dml.DoubleMLIRM(obj_dml_data,
+                                  ml_g, ml_m,
+                                  n_folds,
+                                  score=score,
+                                  dml_procedure=dml_procedure,
+                                  trimming_threshold=trimming_threshold)
+
+    dml_irm_obj.fit()
+
+    np.random.seed(3141)
+    n_obs = len(y)
+    all_smpls = draw_smpls(n_obs, n_folds)
+
+    res_manual = fit_irm(y, x, d,
+                         clone(learner_xgboost[0]), clone(learner_xgboost[1]),
+                         all_smpls, dml_procedure, score, trimming_threshold=trimming_threshold)
+
+    res_dict = {'coef': dml_irm_obj.coef,
+                'coef_manual': res_manual['theta'],
+                'se': dml_irm_obj.se,
+                'se_manual': res_manual['se'],
+                'boot_methods': boot_methods}
+
+    for bootstrap in boot_methods:
+        np.random.seed(3141)
+        boot_theta, boot_t_stat = boot_irm(y, d, res_manual['thetas'], res_manual['ses'],
+                                           res_manual['all_g_hat0'], res_manual['all_g_hat1'],
+                                           res_manual['all_m_hat'], res_manual['all_p_hat'],
+                                           all_smpls, score, bootstrap, n_rep_boot)
+
+        np.random.seed(3141)
+        dml_irm_obj.bootstrap(method=bootstrap, n_rep_boot=n_rep_boot)
+        res_dict['boot_coef' + bootstrap] = dml_irm_obj.boot_coef
+        res_dict['boot_t_stat' + bootstrap] = dml_irm_obj.boot_t_stat
+        res_dict['boot_coef' + bootstrap + '_manual'] = boot_theta
+        res_dict['boot_t_stat' + bootstrap + '_manual'] = boot_t_stat
+
+    return res_dict
+
+
+@pytest.mark.ci
+def test_dml_irm_coef(dml_irm_fixture):
+    assert math.isclose(dml_irm_fixture['coef'],
+                        dml_irm_fixture['coef_manual'],
+                        rel_tol=1e-9, abs_tol=1e-4)
+
+
+@pytest.mark.ci
+def test_dml_irm_se(dml_irm_fixture):
+    assert math.isclose(dml_irm_fixture['se'],
+                        dml_irm_fixture['se_manual'],
+                        rel_tol=1e-9, abs_tol=1e-4)
+
+
+@pytest.mark.ci
+def test_dml_irm_boot(dml_irm_fixture):
+    for bootstrap in dml_irm_fixture['boot_methods']:
+        assert np.allclose(dml_irm_fixture['boot_coef' + bootstrap],
+                           dml_irm_fixture['boot_coef' + bootstrap + '_manual'],
+                           rtol=1e-9, atol=1e-4)
+        assert np.allclose(dml_irm_fixture['boot_t_stat' + bootstrap],
+                           dml_irm_fixture['boot_t_stat' + bootstrap + '_manual'],
+                           rtol=1e-9, atol=1e-4)
+
+
+def test_irm_exception_with_missings(generate_data_irm_w_missings, learner_sklearn):
+    # collect data
+    (x, y, d) = generate_data_irm_w_missings
+
+    # Set machine learning methods for m & g
+    ml_g = clone(learner_sklearn[0])
+    ml_m = clone(learner_sklearn[1])
+
+    np.random.seed(3141)
+    obj_dml_data = dml.DoubleMLData.from_arrays(x, y, d,
+                                                force_all_x_finite=False)
+    dml_irm_obj = dml.DoubleMLIRM(obj_dml_data,
+                                  ml_g, ml_m)
+
+    msg = r"Input contains NaN, infinity or a value too large for dtype\('float64'\)."
+    with pytest.raises(ValueError, match=msg):
+        dml_irm_obj.fit()

--- a/doubleml/tests/test_irm_with_missings.py
+++ b/doubleml/tests/test_irm_with_missings.py
@@ -50,7 +50,7 @@ def trimming_threshold(request):
 
 
 @pytest.fixture(scope='module')
-def dml_irm_fixture(generate_data_irm_w_missings, learner_xgboost, score, dml_procedure, trimming_threshold):
+def dml_irm_w_missing_fixture(generate_data_irm_w_missings, learner_xgboost, score, dml_procedure, trimming_threshold):
     boot_methods = ['normal']
     n_folds = 2
     n_rep_boot = 499
@@ -64,7 +64,7 @@ def dml_irm_fixture(generate_data_irm_w_missings, learner_xgboost, score, dml_pr
 
     np.random.seed(3141)
     obj_dml_data = dml.DoubleMLData.from_arrays(x, y, d,
-                                                force_all_x_finite=False)
+                                                force_all_x_finite='allow-nan')
     dml_irm_obj = dml.DoubleMLIRM(obj_dml_data,
                                   ml_g, ml_m,
                                   n_folds,
@@ -106,27 +106,27 @@ def dml_irm_fixture(generate_data_irm_w_missings, learner_xgboost, score, dml_pr
 
 
 @pytest.mark.ci
-def test_dml_irm_coef(dml_irm_fixture):
-    assert math.isclose(dml_irm_fixture['coef'],
-                        dml_irm_fixture['coef_manual'],
+def test_dml_irm_w_missing_coef(dml_irm_w_missing_fixture):
+    assert math.isclose(dml_irm_w_missing_fixture['coef'],
+                        dml_irm_w_missing_fixture['coef_manual'],
                         rel_tol=1e-9, abs_tol=1e-4)
 
 
 @pytest.mark.ci
-def test_dml_irm_se(dml_irm_fixture):
-    assert math.isclose(dml_irm_fixture['se'],
-                        dml_irm_fixture['se_manual'],
+def test_dml_irm_w_missing_se(dml_irm_w_missing_fixture):
+    assert math.isclose(dml_irm_w_missing_fixture['se'],
+                        dml_irm_w_missing_fixture['se_manual'],
                         rel_tol=1e-9, abs_tol=1e-4)
 
 
 @pytest.mark.ci
-def test_dml_irm_boot(dml_irm_fixture):
-    for bootstrap in dml_irm_fixture['boot_methods']:
-        assert np.allclose(dml_irm_fixture['boot_coef' + bootstrap],
-                           dml_irm_fixture['boot_coef' + bootstrap + '_manual'],
+def test_dml_irm_w_missing_boot(dml_irm_w_missing_fixture):
+    for bootstrap in dml_irm_w_missing_fixture['boot_methods']:
+        assert np.allclose(dml_irm_w_missing_fixture['boot_coef' + bootstrap],
+                           dml_irm_w_missing_fixture['boot_coef' + bootstrap + '_manual'],
                            rtol=1e-9, atol=1e-4)
-        assert np.allclose(dml_irm_fixture['boot_t_stat' + bootstrap],
-                           dml_irm_fixture['boot_t_stat' + bootstrap + '_manual'],
+        assert np.allclose(dml_irm_w_missing_fixture['boot_t_stat' + bootstrap],
+                           dml_irm_w_missing_fixture['boot_t_stat' + bootstrap + '_manual'],
                            rtol=1e-9, atol=1e-4)
 
 
@@ -140,7 +140,7 @@ def test_irm_exception_with_missings(generate_data_irm_w_missings, learner_sklea
 
     np.random.seed(3141)
     obj_dml_data = dml.DoubleMLData.from_arrays(x, y, d,
-                                                force_all_x_finite=False)
+                                                force_all_x_finite='allow-nan')
     dml_irm_obj = dml.DoubleMLIRM(obj_dml_data,
                                   ml_g, ml_m)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 # test
 pytest
 rpy2
+xgboost
 
 # doc
 sphinx


### PR DESCRIPTION
This PR primarily addresses #120.

- As mentioned by @morelandjs in #120 it might be overly restrictive to always call `sklearn.utils.check_X_y()` independent of the provided learner which might be capable to handle missings in the confounders / covariates `x`. To allow such scenarios, the exception handling was reorganized and the API for the data-backend class `DoubleMLData` extended.
- When initializing an object of class `DoubleMLData` via the flag `force_all_x_finite` the user can indicate whether missings / infinite values should be allowed for the confounders `x` (by default `force_all_x_finite=True`), e.g. 
```python
DoubleMLData.from_arrays(x, y, d,
                         force_all_x_finite='allow-nan')
DoubleMLData(df, y_col='y', d_cols='d',
             force_all_x_finite='allow-nan')
```
- Note that the choice `False` and `'allow-nan'` for `force_all_x_finite` are only reasonable if the machine learning methods used for the nuisance functions are capable to provide valid predictions with missings and / or infinite values in the covariates ``x``.

Miscellaneous:
- Added unit tests for the described scenario in #120. Especially also an unit test with `xgboost` learner.
- Added exception handling which ensures that the predictions for the nuisance functions obtained from the ML models are finite.
- Added documentation and unit tests for all new features and exception handling.

