### PR TITLE
Adapt the nuisance estimation for the IV type score in the PLR model 

### DIFF
--- a/doubleml/double_ml_plr.py
+++ b/doubleml/double_ml_plr.py
@@ -16,7 +16,8 @@ class DoubleMLPLR(DoubleML):
 
     ml_g : estimator implementing ``fit()`` and ``predict()``
         A machine learner implementing ``fit()`` and ``predict()`` methods (e.g.
-        :py:class:`sklearn.ensemble.RandomForestRegressor`) for the nuisance function :math:`g_0(X) = E[Y|X]`.
+        :py:class:`sklearn.ensemble.RandomForestRegressor`) for the nuisance functions :math:`l_0(X) = E[Y|X]` and
+        :math:`g_0(X) = E[Y - D \\theta_0|X]`.
 
     ml_m : estimator implementing ``fit()`` and ``predict()``
         A machine learner implementing ``fit()`` and ``predict()`` methods (e.g.

--- a/doubleml/double_ml_plr.py
+++ b/doubleml/double_ml_plr.py
@@ -36,7 +36,7 @@ class DoubleMLPLR(DoubleML):
 
     score : str or callable
         A str (``'partialling out'`` or ``'IV-type'``) specifying the score function
-        or a callable object / function with signature ``psi_a, psi_b = score(y, d, g_hat, m_hat, smpls)``.
+        or a callable object / function with signature ``psi_a, psi_b = score(y, d, l_hat, g_hat, m_hat, smpls)``.
         Default is ``'partialling out'``.
 
     dml_procedure : str
@@ -153,7 +153,7 @@ class DoubleMLPLR(DoubleML):
         # nuisance l
         l_hat = _dml_cv_predict(self._learner['ml_g'], x, y, smpls=smpls, n_jobs=n_jobs_cv,
                                 est_params=self._get_params('ml_l'), method=self._predict_method['ml_g'])
-        _check_finite_predictions(l_hat, self._learner['ml_g'], 'ml_g', smpls)
+        _check_finite_predictions(l_hat, self._learner['ml_g'], 'ml_l', smpls)
 
         # nuisance m
         m_hat = _dml_cv_predict(self._learner['ml_m'], x, d, smpls=smpls, n_jobs=n_jobs_cv,

--- a/doubleml/tests/_utils_plr_manual.py
+++ b/doubleml/tests/_utils_plr_manual.py
@@ -119,7 +119,7 @@ def fit_nuisance_plr(y, x, d, learner_g, learner_m, smpls, fit_g=True,
     m_hat = fit_predict(d, x, ml_m, m_params, smpls)
 
     if fit_g:
-        y_minus_l_hat, _, d_minus_m_hat = compute_plr_residuals(y, d, None, l_hat, m_hat, smpls)
+        y_minus_l_hat, _, d_minus_m_hat = compute_plr_residuals(y, d, [], l_hat, m_hat, smpls)
         psi_a = -np.multiply(d_minus_m_hat, d_minus_m_hat)
         psi_b = np.multiply(d_minus_m_hat, y_minus_l_hat)
         theta_initial = -np.nanmean(psi_b) / np.nanmean(psi_a)
@@ -141,7 +141,7 @@ def fit_nuisance_plr_classifier(y, x, d, learner_g, learner_m, smpls, fit_g=True
     m_hat = fit_predict_proba(d, x, ml_m, m_params, smpls)
 
     if fit_g:
-        y_minus_l_hat, _, d_minus_m_hat = compute_plr_residuals(y, d, None, l_hat, m_hat, smpls)
+        y_minus_l_hat, _, d_minus_m_hat = compute_plr_residuals(y, d, [], l_hat, m_hat, smpls)
         psi_a = -np.multiply(d_minus_m_hat, d_minus_m_hat)
         psi_b = np.multiply(d_minus_m_hat, y_minus_l_hat)
         theta_initial = -np.mean(psi_b) / np.mean(psi_a)
@@ -186,7 +186,7 @@ def compute_plr_residuals(y, d, g_hat, l_hat, m_hat, smpls):
     d_minus_m_hat = np.full_like(d, np.nan, dtype='float64')
     for idx, (_, test_index) in enumerate(smpls):
         y_minus_l_hat[test_index] = y[test_index] - l_hat[idx]
-        if g_hat is not None:
+        if len(g_hat) > 0:
             y_minus_g_hat[test_index] = y[test_index] - g_hat[idx]
         d_minus_m_hat[test_index] = d[test_index] - m_hat[idx]
     return y_minus_l_hat, y_minus_g_hat, d_minus_m_hat

--- a/doubleml/tests/_utils_plr_manual.py
+++ b/doubleml/tests/_utils_plr_manual.py
@@ -127,7 +127,7 @@ def fit_nuisance_plr(y, x, d, learner_g, learner_m, smpls, fit_g=True,
         ml_g = clone(learner_g)
         g_hat = fit_predict(y - theta_initial*d, x, ml_g, g_params, smpls)
     else:
-        g_hat = None
+        g_hat = []
 
     return g_hat, l_hat, m_hat
 
@@ -149,7 +149,7 @@ def fit_nuisance_plr_classifier(y, x, d, learner_g, learner_m, smpls, fit_g=True
         ml_g = clone(learner_g)
         g_hat = fit_predict(y - theta_initial*d, x, ml_g, g_params, smpls)
     else:
-        g_hat = None
+        g_hat = []
 
     return g_hat, l_hat, m_hat
 

--- a/doubleml/tests/_utils_plr_manual.py
+++ b/doubleml/tests/_utils_plr_manual.py
@@ -7,7 +7,7 @@ from ._utils import fit_predict, fit_predict_proba, tune_grid_search
 
 
 def fit_plr_multitreat(y, x, d, learner_g, learner_m, all_smpls, dml_procedure, score,
-                       n_rep=1, g_params=None, m_params=None,
+                       n_rep=1, g_params=None, l_params=None, m_params=None,
                        use_other_treat_as_covariate=True):
     n_obs = len(y)
     n_d = d.shape[1]
@@ -15,12 +15,14 @@ def fit_plr_multitreat(y, x, d, learner_g, learner_m, all_smpls, dml_procedure, 
     thetas = list()
     ses = list()
     all_g_hat = list()
+    all_l_hat = list()
     all_m_hat = list()
     for i_rep in range(n_rep):
         smpls = all_smpls[i_rep]
         thetas_this_rep = np.full(n_d, np.nan)
         ses_this_rep = np.full(n_d, np.nan)
         all_g_hat_this_rep = list()
+        all_l_hat_this_rep = list()
         all_m_hat_this_rep = list()
 
         for i_d in range(n_d):
@@ -29,14 +31,16 @@ def fit_plr_multitreat(y, x, d, learner_g, learner_m, all_smpls, dml_procedure, 
             else:
                 xd = x
 
-            g_hat, m_hat, thetas_this_rep[i_d], ses_this_rep[i_d] = fit_plr_single_split(
-                y, xd, d[:, i_d], learner_g, learner_m, smpls, dml_procedure, score, g_params, m_params)
+            g_hat, l_hat, m_hat, thetas_this_rep[i_d], ses_this_rep[i_d] = fit_plr_single_split(
+                y, xd, d[:, i_d], learner_g, learner_m, smpls, dml_procedure, score, g_params, l_params, m_params)
             all_g_hat_this_rep.append(g_hat)
+            all_l_hat_this_rep.append(l_hat)
             all_m_hat_this_rep.append(m_hat)
 
         thetas.append(thetas_this_rep)
         ses.append(ses_this_rep)
         all_g_hat.append(all_g_hat_this_rep)
+        all_l_hat.append(all_l_hat_this_rep)
         all_m_hat.append(all_m_hat_this_rep)
 
     theta = np.full(n_d, np.nan)
@@ -49,24 +53,26 @@ def fit_plr_multitreat(y, x, d, learner_g, learner_m, all_smpls, dml_procedure, 
 
     res = {'theta': theta, 'se': se,
            'thetas': thetas, 'ses': ses,
-           'all_g_hat': all_g_hat, 'all_m_hat': all_m_hat}
+           'all_g_hat': all_g_hat, 'all_l_hat': all_l_hat, 'all_m_hat': all_m_hat}
 
     return res
 
 
 def fit_plr(y, x, d, learner_g, learner_m, all_smpls, dml_procedure, score,
-            n_rep=1, g_params=None, m_params=None):
+            n_rep=1, g_params=None, l_params=None, m_params=None):
     n_obs = len(y)
 
     thetas = np.zeros(n_rep)
     ses = np.zeros(n_rep)
     all_g_hat = list()
+    all_l_hat = list()
     all_m_hat = list()
     for i_rep in range(n_rep):
         smpls = all_smpls[i_rep]
-        g_hat, m_hat, thetas[i_rep], ses[i_rep] = fit_plr_single_split(
-            y, x, d, learner_g, learner_m, smpls, dml_procedure, score, g_params, m_params)
+        g_hat, l_hat, m_hat, thetas[i_rep], ses[i_rep] = fit_plr_single_split(
+            y, x, d, learner_g, learner_m, smpls, dml_procedure, score, g_params, l_params, m_params)
         all_g_hat.append(g_hat)
+        all_l_hat.append(l_hat)
         all_m_hat.append(m_hat)
 
     theta = np.median(thetas)
@@ -74,78 +80,124 @@ def fit_plr(y, x, d, learner_g, learner_m, all_smpls, dml_procedure, score,
 
     res = {'theta': theta, 'se': se,
            'thetas': thetas, 'ses': ses,
-           'all_g_hat': all_g_hat, 'all_m_hat': all_m_hat}
+           'all_g_hat': all_g_hat, 'all_l_hat': all_l_hat, 'all_m_hat': all_m_hat}
 
     return res
 
 
-def fit_plr_single_split(y, x, d, learner_g, learner_m, smpls, dml_procedure, score, g_params=None, m_params=None):
+def fit_plr_single_split(y, x, d, learner_g, learner_m, smpls, dml_procedure, score,
+                         g_params=None, l_params=None, m_params=None):
+    fit_g = (score == 'IV-type') | callable(score)
     if is_classifier(learner_m):
-        g_hat, m_hat = fit_nuisance_plr_classifier(y, x, d,
-                                                   learner_g, learner_m, smpls,
-                                                   g_params, m_params)
+        g_hat, l_hat, m_hat = fit_nuisance_plr_classifier(y, x, d,
+                                                          learner_g, learner_m, smpls, fit_g,
+                                                          g_params, l_params, m_params)
     else:
-        g_hat, m_hat = fit_nuisance_plr(y, x, d,
-                                        learner_g, learner_m, smpls,
-                                        g_params, m_params)
+        g_hat, l_hat, m_hat = fit_nuisance_plr(y, x, d,
+                                               learner_g, learner_m, smpls, fit_g,
+                                               g_params, l_params, m_params)
 
     if dml_procedure == 'dml1':
         theta, se = plr_dml1(y, x, d,
-                             g_hat, m_hat,
+                             g_hat, l_hat, m_hat,
                              smpls, score)
     else:
         assert dml_procedure == 'dml2'
         theta, se = plr_dml2(y, x, d,
-                             g_hat, m_hat,
+                             g_hat, l_hat, m_hat,
                              smpls, score)
 
-    return g_hat, m_hat, theta, se
+    return g_hat, l_hat, m_hat, theta, se
 
 
-def fit_nuisance_plr(y, x, d, learner_g, learner_m, smpls, g_params=None, m_params=None):
-    ml_g = clone(learner_g)
-    g_hat = fit_predict(y, x, ml_g, g_params, smpls)
+def fit_nuisance_plr(y, x, d, learner_g, learner_m, smpls, fit_g=True,
+                     g_params=None, l_params=None, m_params=None):
+    ml_l = clone(learner_g)
+    l_hat = fit_predict(y, x, ml_l, l_params, smpls)
 
     ml_m = clone(learner_m)
     m_hat = fit_predict(d, x, ml_m, m_params, smpls)
 
-    return g_hat, m_hat
+    if fit_g:
+        u_hat, v_hat = compute_plr_residuals(y, d, None, l_hat, m_hat, smpls, 'partialling out')
+        psi_a = -np.multiply(v_hat, v_hat)
+        psi_b = np.multiply(v_hat, u_hat)
+        theta_initial = -np.nanmean(psi_b) / np.nanmean(psi_a)
+
+        ml_g = clone(learner_g)
+        g_hat = fit_predict(y - theta_initial*d, x, ml_g, g_params, smpls)
+    else:
+        g_hat = None
+
+    return g_hat, l_hat, m_hat
 
 
-def fit_nuisance_plr_classifier(y, x, d, learner_g, learner_m, smpls, g_params=None, m_params=None):
-    ml_g = clone(learner_g)
-    g_hat = fit_predict(y, x, ml_g, g_params, smpls)
+def fit_nuisance_plr_classifier(y, x, d, learner_g, learner_m, smpls, fit_g=True,
+                                g_params=None, l_params=None, m_params=None):
+    ml_l = clone(learner_g)
+    l_hat = fit_predict(y, x, ml_l, l_params, smpls)
 
     ml_m = clone(learner_m)
     m_hat = fit_predict_proba(d, x, ml_m, m_params, smpls)
 
-    return g_hat, m_hat
+    if fit_g:
+        u_hat, v_hat = compute_plr_residuals(y, d, None, l_hat, m_hat, smpls, 'partialling out')
+        psi_a = -np.multiply(v_hat, v_hat)
+        psi_b = np.multiply(v_hat, u_hat)
+        theta_initial = -np.mean(psi_b) / np.mean(psi_a)
+
+        ml_g = clone(learner_g)
+        g_hat = fit_predict(y - theta_initial*d, x, ml_g, g_params, smpls)
+    else:
+        g_hat = None
+
+    return g_hat, l_hat, m_hat
 
 
-def tune_nuisance_plr(y, x, d, ml_g, ml_m, smpls, n_folds_tune, param_grid_g, param_grid_m):
-    g_tune_res = tune_grid_search(y, x, ml_g, smpls, param_grid_g, n_folds_tune)
+def tune_nuisance_plr(y, x, d, ml_g, ml_m, smpls, n_folds_tune, param_grid_g, param_grid_m, tune_g=True):
+    l_tune_res = tune_grid_search(y, x, ml_g, smpls, param_grid_g, n_folds_tune)
 
     m_tune_res = tune_grid_search(d, x, ml_m, smpls, param_grid_m, n_folds_tune)
 
-    g_best_params = [xx.best_params_ for xx in g_tune_res]
+    if tune_g:
+        l_hat = np.full_like(y, np.nan)
+        m_hat = np.full_like(d, np.nan)
+        for idx, (train_index, _) in enumerate(smpls):
+            l_hat[train_index] = l_tune_res[idx].predict(x[train_index, :])
+            m_hat[train_index] = m_tune_res[idx].predict(x[train_index, :])
+        psi_a = -np.multiply(d - m_hat, d - m_hat)
+        psi_b = np.multiply(d - m_hat, y - l_hat)
+        theta_initial = -np.nanmean(psi_b) / np.nanmean(psi_a)
+
+        g_tune_res = tune_grid_search(y - theta_initial*d, x, ml_g, smpls, param_grid_g, n_folds_tune)
+        g_best_params = [xx.best_params_ for xx in g_tune_res]
+    else:
+        g_best_params = []
+
+    l_best_params = [xx.best_params_ for xx in l_tune_res]
     m_best_params = [xx.best_params_ for xx in m_tune_res]
 
-    return g_best_params, m_best_params
+    return g_best_params, l_best_params, m_best_params
 
 
-def compute_plr_residuals(y, d, g_hat, m_hat, smpls):
+def compute_plr_residuals(y, d, g_hat, l_hat, m_hat, smpls, score):
+    # Note that u_hat is not the same for score = 'partialling out' vs. score = 'IV-type'
     u_hat = np.full_like(y, np.nan, dtype='float64')
     v_hat = np.full_like(d, np.nan, dtype='float64')
     for idx, (_, test_index) in enumerate(smpls):
-        u_hat[test_index] = y[test_index] - g_hat[idx]
+        if score == 'partialling out':
+            u_hat[test_index] = y[test_index] - l_hat[idx]
+        else:
+            assert score == 'IV-type'
+            u_hat[test_index] = y[test_index] - g_hat[idx]
         v_hat[test_index] = d[test_index] - m_hat[idx]
     return u_hat, v_hat
 
 
-def plr_dml1(y, x, d, g_hat, m_hat, smpls, score):
+def plr_dml1(y, x, d, g_hat, l_hat, m_hat, smpls, score):
     thetas = np.zeros(len(smpls))
     n_obs = len(y)
-    u_hat, v_hat = compute_plr_residuals(y, d, g_hat, m_hat, smpls)
+    u_hat, v_hat = compute_plr_residuals(y, d, g_hat, l_hat, m_hat, smpls, score)
 
     for idx, (_, test_index) in enumerate(smpls):
         thetas[idx] = plr_orth(v_hat[test_index], u_hat[test_index], d[test_index], score)
@@ -157,14 +209,15 @@ def plr_dml1(y, x, d, g_hat, m_hat, smpls, score):
         assert len(smpls) == 1
         test_index = smpls[0][1]
         n_obs = len(test_index)
-        se = np.sqrt(var_plr(theta_hat, d[test_index], u_hat[test_index], v_hat[test_index], score, n_obs))
+        se = np.sqrt(var_plr(theta_hat, d[test_index], u_hat[test_index], v_hat[test_index],
+                             score, n_obs))
 
     return theta_hat, se
 
 
-def plr_dml2(y, x, d, g_hat, m_hat, smpls, score):
+def plr_dml2(y, x, d, g_hat, l_hat, m_hat, smpls, score):
     n_obs = len(y)
-    u_hat, v_hat = compute_plr_residuals(y, d, g_hat, m_hat, smpls)
+    u_hat, v_hat = compute_plr_residuals(y, d, g_hat, l_hat, m_hat, smpls, score)
     theta_hat = plr_orth(v_hat, u_hat, d, score)
     se = np.sqrt(var_plr(theta_hat, d, u_hat, v_hat, score, n_obs))
 
@@ -193,7 +246,7 @@ def plr_orth(v_hat, u_hat, d, score):
     return res
 
 
-def boot_plr(y, d, thetas, ses, all_g_hat, all_m_hat,
+def boot_plr(y, d, thetas, ses, all_g_hat, all_l_hat, all_m_hat,
              all_smpls, score, bootstrap, n_rep_boot,
              n_rep=1, apply_cross_fitting=True):
     all_boot_theta = list()
@@ -208,7 +261,7 @@ def boot_plr(y, d, thetas, ses, all_g_hat, all_m_hat,
         weights = draw_weights(bootstrap, n_rep_boot, n_obs)
 
         boot_theta, boot_t_stat = boot_plr_single_split(
-            thetas[i_rep], y, d, all_g_hat[i_rep], all_m_hat[i_rep], smpls,
+            thetas[i_rep], y, d, all_g_hat[i_rep], all_l_hat[i_rep], all_m_hat[i_rep], smpls,
             score, ses[i_rep],
             weights, n_rep_boot, apply_cross_fitting)
         all_boot_theta.append(boot_theta)
@@ -220,7 +273,7 @@ def boot_plr(y, d, thetas, ses, all_g_hat, all_m_hat,
     return boot_theta, boot_t_stat
 
 
-def boot_plr_multitreat(y, d, thetas, ses, all_g_hat, all_m_hat,
+def boot_plr_multitreat(y, d, thetas, ses, all_g_hat, all_l_hat, all_m_hat,
                         all_smpls, score, bootstrap, n_rep_boot,
                         n_rep=1, apply_cross_fitting=True):
     n_d = d.shape[1]
@@ -240,7 +293,7 @@ def boot_plr_multitreat(y, d, thetas, ses, all_g_hat, all_m_hat,
         for i_d in range(n_d):
             boot_theta[i_d, :], boot_t_stat[i_d, :] = boot_plr_single_split(
                 thetas[i_rep][i_d], y, d[:, i_d],
-                all_g_hat[i_rep][i_d], all_m_hat[i_rep][i_d],
+                all_g_hat[i_rep][i_d], all_l_hat[i_rep][i_d], all_m_hat[i_rep][i_d],
                 smpls, score, ses[i_rep][i_d],
                 weights, n_rep_boot, apply_cross_fitting)
         all_boot_theta.append(boot_theta)
@@ -252,9 +305,9 @@ def boot_plr_multitreat(y, d, thetas, ses, all_g_hat, all_m_hat,
     return boot_theta, boot_t_stat
 
 
-def boot_plr_single_split(theta, y, d, g_hat, m_hat,
+def boot_plr_single_split(theta, y, d, g_hat, l_hat, m_hat,
                           smpls, score, se, weights, n_rep, apply_cross_fitting):
-    u_hat, v_hat = compute_plr_residuals(y, d, g_hat, m_hat, smpls)
+    u_hat, v_hat = compute_plr_residuals(y, d, g_hat, l_hat, m_hat, smpls, score)
 
     if apply_cross_fitting:
         if score == 'partialling out':

--- a/doubleml/tests/test_doubleml_exceptions.py
+++ b/doubleml/tests/test_doubleml_exceptions.py
@@ -576,10 +576,10 @@ class LassoWithInfPred(Lasso):
 @pytest.mark.ci
 def test_doubleml_nan_prediction():
 
-    msg = r'Predictions from learner LassoWithNanPred\(\) for ml_g are not finite.'
+    msg = r'Predictions from learner LassoWithNanPred\(\) for ml_l are not finite.'
     with pytest.raises(ValueError, match=msg):
         _ = DoubleMLPLR(dml_data, LassoWithNanPred(), ml_m).fit()
-    msg = r'Predictions from learner LassoWithInfPred\(\) for ml_g are not finite.'
+    msg = r'Predictions from learner LassoWithInfPred\(\) for ml_l are not finite.'
     with pytest.raises(ValueError, match=msg):
         _ = DoubleMLPLR(dml_data, LassoWithInfPred(), ml_m).fit()
 

--- a/doubleml/tests/test_doubleml_exceptions.py
+++ b/doubleml/tests/test_doubleml_exceptions.py
@@ -15,6 +15,7 @@ ml_g = Lasso()
 ml_m = Lasso()
 ml_r = Lasso()
 dml_plr = DoubleMLPLR(dml_data, ml_g, ml_m)
+dml_plr_iv_type = DoubleMLPLR(dml_data, ml_g, ml_m, score='IV-type')
 
 dml_data_irm = make_irm_data(n_obs=10)
 dml_data_iivm = make_iivm_data(n_obs=10)
@@ -218,9 +219,17 @@ def test_doubleml_exception_no_cross_fit():
 
 @pytest.mark.ci
 def test_doubleml_exception_get_params():
-    msg = 'Invalid nuisance learner ml_r. Valid nuisance learner ml_g or ml_m.'
+    msg = 'Invalid nuisance learner ml_r. Valid nuisance learner ml_l or ml_m.'
     with pytest.raises(ValueError, match=msg):
         dml_plr.get_params('ml_r')
+    msg = 'Invalid nuisance learner ml_g. Valid nuisance learner ml_l or ml_m.'
+    with pytest.raises(ValueError, match=msg):
+        dml_plr.get_params('ml_g')
+    msg = 'Invalid nuisance learner ml_r. Valid nuisance learner ml_l or ml_g or ml_m.'
+    with pytest.raises(ValueError, match=msg):
+        dml_plr_iv_type.get_params('ml_r')
+
+
 
 
 @pytest.mark.ci
@@ -375,12 +384,12 @@ def test_doubleml_exception_tune():
 @pytest.mark.ci
 def test_doubleml_exception_set_ml_nuisance_params():
 
-    msg = 'Invalid nuisance learner g. Valid nuisance learner ml_g or ml_m.'
+    msg = 'Invalid nuisance learner g. Valid nuisance learner ml_l or ml_m.'
     with pytest.raises(ValueError, match=msg):
         dml_plr.set_ml_nuisance_params('g', 'd', {'alpha': 0.1})
     msg = 'Invalid treatment variable y. Valid treatment variable d.'
     with pytest.raises(ValueError, match=msg):
-        dml_plr.set_ml_nuisance_params('ml_g', 'y', {'alpha': 0.1})
+        dml_plr.set_ml_nuisance_params('ml_l', 'y', {'alpha': 0.1})
 
 
 class _DummyNoSetParams:

--- a/doubleml/tests/test_doubleml_scores.py
+++ b/doubleml/tests/test_doubleml_scores.py
@@ -63,10 +63,11 @@ def test_plr_callable_vs_str_score():
 @pytest.mark.ci
 def test_plr_callable_vs_pred_export():
     preds = dml_plr_callable_score.predictions
+    l_hat = preds['ml_l'].squeeze()
     g_hat = preds['ml_g'].squeeze()
     m_hat = preds['ml_m'].squeeze()
     psi_a, psi_b = plr_score(dml_data_plr.y, dml_data_plr.d,
-                             g_hat, m_hat,
+                             l_hat, g_hat, m_hat,
                              dml_plr_callable_score.smpls[0])
     assert np.allclose(dml_plr.psi_a.squeeze(),
                        psi_a,

--- a/doubleml/tests/test_plr_classifier.py
+++ b/doubleml/tests/test_plr_classifier.py
@@ -74,7 +74,7 @@ def dml_plr_binary_classifier_fixture(learner, score, dml_procedure):
     for bootstrap in boot_methods:
         np.random.seed(3141)
         boot_theta, boot_t_stat = boot_plr(y, d, res_manual['thetas'], res_manual['ses'],
-                                           res_manual['all_g_hat'], res_manual['all_m_hat'],
+                                           res_manual['all_g_hat'], res_manual['all_l_hat'], res_manual['all_m_hat'],
                                            all_smpls, score, bootstrap, n_rep_boot)
 
         np.random.seed(3141)

--- a/doubleml/tests/test_plr_multi_treat.py
+++ b/doubleml/tests/test_plr_multi_treat.py
@@ -96,7 +96,7 @@ def dml_plr_multitreat_fixture(generate_data_bivariate, generate_data_toeplitz, 
         boot_theta, boot_t_stat = boot_plr_multitreat(
             y, d,
             res_manual['thetas'], res_manual['ses'],
-            res_manual['all_g_hat'], res_manual['all_m_hat'],
+            res_manual['all_g_hat'], res_manual['all_l_hat'], res_manual['all_m_hat'],
             all_smpls, score,
             bootstrap, n_rep_boot, n_rep)
 

--- a/doubleml/tests/test_plr_rep_cross.py
+++ b/doubleml/tests/test_plr_rep_cross.py
@@ -83,7 +83,7 @@ def dml_plr_fixture(generate_data1, learner, score, dml_procedure, n_rep):
     for bootstrap in boot_methods:
         np.random.seed(3141)
         boot_theta, boot_t_stat = boot_plr(y, d, res_manual['thetas'], res_manual['ses'],
-                                           res_manual['all_g_hat'], res_manual['all_m_hat'],
+                                           res_manual['all_g_hat'], res_manual['all_l_hat'], res_manual['all_m_hat'],
                                            all_smpls, score, bootstrap, n_rep_boot, n_rep)
 
         np.random.seed(3141)

--- a/doubleml/tests/test_plr_set_ml_nuisance_pars.py
+++ b/doubleml/tests/test_plr_set_ml_nuisance_pars.py
@@ -56,8 +56,11 @@ def dml_plr_fixture(generate_data1, score, dml_procedure):
                                               n_folds,
                                               score=score,
                                               dml_procedure=dml_procedure)
-    dml_plr_obj_ext_set_par.set_ml_nuisance_params('ml_g', 'd', {'alpha': alpha})
+    dml_plr_obj_ext_set_par.set_ml_nuisance_params('ml_l', 'd', {'alpha': alpha})
     dml_plr_obj_ext_set_par.set_ml_nuisance_params('ml_m', 'd', {'alpha': alpha})
+    if score == 'IV-type':
+        dml_plr_obj_ext_set_par.set_ml_nuisance_params('ml_g', 'd', {'alpha': alpha})
+
     dml_plr_obj_ext_set_par.fit()
 
     res_dict = {'coef': dml_plr_obj.coef,

--- a/doubleml/tests/test_plr_tune.py
+++ b/doubleml/tests/test_plr_tune.py
@@ -91,21 +91,23 @@ def dml_plr_fixture(generate_data2, learner_g, learner_m, score, dml_procedure, 
     all_smpls = draw_smpls(n_obs, n_folds)
     smpls = all_smpls[0]
 
+    tune_g = score == 'IV-type'
     if tune_on_folds:
-        g_params, m_params = tune_nuisance_plr(y, x, d,
-                                               clone(learner_g), clone(learner_m), smpls, n_folds_tune,
-                                               par_grid['ml_g'], par_grid['ml_m'])
+        g_params, l_params, m_params = tune_nuisance_plr(y, x, d,
+                                                         clone(learner_g), clone(learner_m), smpls, n_folds_tune,
+                                                         par_grid['ml_g'], par_grid['ml_m'], tune_g)
     else:
         xx = [(np.arange(len(y)), np.array([]))]
-        g_params, m_params = tune_nuisance_plr(y, x, d,
-                                               clone(learner_g), clone(learner_m), xx, n_folds_tune,
-                                               par_grid['ml_g'], par_grid['ml_m'])
+        g_params, l_params, m_params = tune_nuisance_plr(y, x, d,
+                                                         clone(learner_g), clone(learner_m), xx, n_folds_tune,
+                                                         par_grid['ml_g'], par_grid['ml_m'], tune_g)
+        l_params = l_params * n_folds
         g_params = g_params * n_folds
         m_params = m_params * n_folds
 
     res_manual = fit_plr(y, x, d, clone(learner_g), clone(learner_m),
                          all_smpls, dml_procedure, score,
-                         g_params=g_params, m_params=m_params)
+                         g_params=g_params, l_params=l_params, m_params=m_params)
 
     res_dict = {'coef': dml_plr_obj.coef,
                 'coef_manual': res_manual['theta'],
@@ -116,7 +118,7 @@ def dml_plr_fixture(generate_data2, learner_g, learner_m, score, dml_procedure, 
     for bootstrap in boot_methods:
         np.random.seed(3141)
         boot_theta, boot_t_stat = boot_plr(y, d, res_manual['thetas'], res_manual['ses'],
-                                           res_manual['all_g_hat'], res_manual['all_m_hat'],
+                                           res_manual['all_g_hat'], res_manual['all_l_hat'], res_manual['all_m_hat'],
                                            all_smpls, score, bootstrap, n_rep_boot)
 
         np.random.seed(3141)


### PR DESCRIPTION
### Description
In this PR the nuisance estimation for the IV-type score in the PLR model is adapted to be in line with the DML paper [Chernozhukov et al. (2018)](https://doi.org/10.1111/ectj.12097).
* Results for the default `score='partialling out'` (Equation (4.4) in [Chernozhukov et al. (2018)](https://doi.org/10.1111/ectj.12097)) are not affected by the changes in this PR. However, the naming of the predictions is changed from `g_hat` to `l_hat` to be better in line with [Chernozhukov et al. (2018)](https://doi.org/10.1111/ectj.12097). Still the API is not changed to be backward-compatible, i.e., when initializing an `DoubleMLPLR` object, learners `ml_g` and `ml_m` need to be specified. The estimator `ml_g` is then used to estimate the effect of `X` on `Y` (i.e. l_0(X) = E[Y|X]) and the estimator `ml_m` to estimate the effect of `X` on `D` (i.e. m_0(X) = E[D|X]). When setting hyperparamters `learner='ml_l'` and `learner='ml_m'` should be used.
* For the `score='IV-type'` (Equation (4.3) in [Chernozhukov et al. (2018)](https://doi.org/10.1111/ectj.12097)) the implementation now follows the approach described on pp. C31-C33 in [Chernozhukov et al. (2018)](https://doi.org/10.1111/ectj.12097). This means that an initial estimate for `theta_0` is obtained via the `'partialling out'` score. Then an estimate for `g_0(X)` is obtained by regressing `Y - theta_0 * D` on `X`. For both nuisance functions `l_0(X)` (needed for the preliminary `theta_0` estimate) and `g_0(X)`, the same ML estimator (specified in `ml_g`) is used. However, hyperparamters can be set individually via `learner='ml_l'` and `learner='ml_m'`.

### PR Checklist

- [x] The title of the pull request summarizes the changes made.
- [x] The PR contains a detailed description of all changes and additions.
- [x] References to related issues or PRs are added.
- [x] The code passes all (unit) tests.
- [x] Enhancements or new feature are equipped with unit tests.
- [x] The changes adhere to the PEP8 standards.
