### PR TITLE
Adapt to sklearn 1.1.0

### DIFF
--- a/doubleml/tests/test_dml_data.py
+++ b/doubleml/tests/test_dml_data.py
@@ -462,7 +462,7 @@ def test_dml_data_w_missings(generate_data_irm_w_missings):
     _ = DoubleMLData.from_arrays(x, y, d,
                                  force_all_x_finite='allow-nan')
 
-    msg = r"Input contains NaN, infinity or a value too large for dtype\('float64'\)."
+    msg = r"Input contains NaN."
     with pytest.raises(ValueError, match=msg):
         _ = DoubleMLData.from_arrays(x, y, d,
                                      force_all_x_finite=True)
@@ -504,7 +504,7 @@ def test_dml_data_w_missings(generate_data_irm_w_missings):
                          y_col='y', d_cols='d',
                          force_all_x_finite='allownan')
 
-    msg = r"Input contains NaN, infinity or a value too large for dtype\('float64'\)."
+    msg = r"Input contains NaN."
     with pytest.raises(ValueError, match=msg):
         dml_data.force_all_x_finite = True
 

--- a/doubleml/tests/test_irm_with_missings.py
+++ b/doubleml/tests/test_irm_with_missings.py
@@ -144,6 +144,6 @@ def test_irm_exception_with_missings(generate_data_irm_w_missings, learner_sklea
     dml_irm_obj = dml.DoubleMLIRM(obj_dml_data,
                                   ml_g, ml_m)
 
-    msg = r"Input contains NaN, infinity or a value too large for dtype\('float64'\)."
+    msg = r"Input X contains NaN.\nLinearRegression does not accept missing values encoded as NaN natively."
     with pytest.raises(ValueError, match=msg):
         dml_irm_obj.fit()


### PR DESCRIPTION
Fix some unit tests for expception handling which are affected by the newly released `scikit-learn` in version `1.1.0`.