### PR TITLE
Store estimated models for nuisance parameters

### DIFF
--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -994,7 +994,7 @@ class DoubleML(ABC):
                              for learner in self.params_names}
 
     def _initialize_models(self):
-        self._models = {learner: None
+        self._models = {learner: {treat_var: [None] * self.n_rep for treat_var in self._dml_data.d_cols}
                         for learner in self.params_names}
 
     def _store_predictions(self, preds):
@@ -1003,7 +1003,7 @@ class DoubleML(ABC):
 
     def _store_models(self, models):
         for learner in self.params_names:
-            self._models[learner] = models[learner]
+            self._models[learner][self._dml_data.d_cols[self._i_treat]][self._i_rep] = models[learner]
 
     def draw_sample_splitting(self):
         """

--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -45,6 +45,9 @@ class DoubleML(ABC):
         # initialize predictions to None which are only stored if method fit is called with store_predictions=True
         self._predictions = None
 
+        # initialize models to None which are only stored if method fit is called with store_models=True
+        self._models = None
+
         # check resampling specifications
         if not isinstance(n_folds, int):
             raise TypeError('The number of folds must be of int type. '
@@ -225,6 +228,13 @@ class DoubleML(ABC):
         The predictions of the nuisance models.
         """
         return self._predictions
+
+    @property
+    def models(self):
+        """
+        The fitted nuisance models.
+        """
+        return self._models
 
     def get_params(self, learner):
         """
@@ -424,7 +434,7 @@ class DoubleML(ABC):
     def __all_se(self):
         return self._all_se[self._i_treat, self._i_rep]
 
-    def fit(self, n_jobs_cv=None, keep_scores=True, store_predictions=False):
+    def fit(self, n_jobs_cv=None, keep_scores=True, store_predictions=False, store_models=False):
         """
         Estimate DoubleML models.
 
@@ -439,7 +449,12 @@ class DoubleML(ABC):
             Default is ``True``.
 
         store_predictions : bool
-            Indicates whether the predictions for the nuisance functions should be be stored in ``predictions``.
+            Indicates whether the predictions for the nuisance functions should be stored in ``predictions``.
+            Default is ``False``.
+
+        store_models : bool
+            Indicates whether the fitted models for the nuisance functions should be stored in ``models``. This allows
+            to analyze the fitted models or extract information like variable importance.
             Default is ``False``.
 
         Returns
@@ -460,8 +475,15 @@ class DoubleML(ABC):
             raise TypeError('store_predictions must be True or False. '
                             f'Got {str(store_predictions)}.')
 
+        if not isinstance(store_models, bool):
+            raise TypeError('store_models must be True or False. '
+                            f'Got {str(store_models)}.')
+
         if store_predictions:
             self._initialize_predictions()
+
+        if store_models:
+            self._initialize_models()
 
         for i_rep in range(self.n_rep):
             self._i_rep = i_rep
@@ -474,10 +496,12 @@ class DoubleML(ABC):
 
                 # ml estimation of nuisance models and computation of score elements
                 self._psi_a[:, self._i_rep, self._i_treat], self._psi_b[:, self._i_rep, self._i_treat], preds =\
-                    self._nuisance_est(self.__smpls, n_jobs_cv)
+                    self._nuisance_est(self.__smpls, n_jobs_cv, return_models=store_models)
 
                 if store_predictions:
-                    self._store_predictions(preds)
+                    self._store_predictions(preds['predictions'])
+                if store_models:
+                    self._store_models(preds['models'])
 
                 # estimate the causal parameter
                 self._all_coef[self._i_treat, self._i_rep] = self._est_causal_pars()
@@ -887,7 +911,7 @@ class DoubleML(ABC):
         pass
 
     @abstractmethod
-    def _nuisance_est(self, smpls, n_jobs_cv):
+    def _nuisance_est(self, smpls, n_jobs_cv, return_models):
         pass
 
     @abstractmethod
@@ -969,9 +993,17 @@ class DoubleML(ABC):
         self._predictions = {learner: np.full((self._dml_data.n_obs, self.n_rep, self._dml_data.n_treat), np.nan)
                              for learner in self.params_names}
 
+    def _initialize_models(self):
+        self._models = {learner: None
+                        for learner in self.params_names}
+
     def _store_predictions(self, preds):
         for learner in self.params_names:
             self._predictions[learner][:, self._i_rep, self._i_treat] = preds[learner]
+
+    def _store_models(self, models):
+        for learner in self.params_names:
+            self._models[learner] = models[learner]
 
     def draw_sample_splitting(self):
         """

--- a/doubleml/double_ml_plr.py
+++ b/doubleml/double_ml_plr.py
@@ -197,7 +197,7 @@ class DoubleMLPLR(DoubleML):
             learner = 'ml_l'
         super(DoubleMLPLR, self).set_ml_nuisance_params(learner, treat_var, params)
 
-    def _nuisance_est(self, smpls, n_jobs_cv):
+    def _nuisance_est(self, smpls, n_jobs_cv, return_models=False):
         x, y = check_X_y(self._dml_data.x, self._dml_data.y,
                          force_all_finite=False)
         x, d = check_X_y(x, self._dml_data.d,
@@ -205,17 +205,19 @@ class DoubleMLPLR(DoubleML):
 
         # nuisance l
         l_hat = _dml_cv_predict(self._learner['ml_l'], x, y, smpls=smpls, n_jobs=n_jobs_cv,
-                                est_params=self._get_params('ml_l'), method=self._predict_method['ml_l'])
-        _check_finite_predictions(l_hat, self._learner['ml_l'], 'ml_l', smpls)
+                                est_params=self._get_params('ml_l'), method=self._predict_method['ml_l'],
+                                return_models=return_models)
+        _check_finite_predictions(l_hat['preds'], self._learner['ml_l'], 'ml_l', smpls)
 
         # nuisance m
         m_hat = _dml_cv_predict(self._learner['ml_m'], x, d, smpls=smpls, n_jobs=n_jobs_cv,
-                                est_params=self._get_params('ml_m'), method=self._predict_method['ml_m'])
-        _check_finite_predictions(m_hat, self._learner['ml_m'], 'ml_m', smpls)
+                                est_params=self._get_params('ml_m'), method=self._predict_method['ml_m'],
+                                return_models=return_models)
+        _check_finite_predictions(m_hat['preds'], self._learner['ml_m'], 'ml_m', smpls)
 
         if self._dml_data.binary_treats[self._dml_data.d_cols[self._i_treat]]:
-            binary_preds = (type_of_target(m_hat) == 'binary')
-            zero_one_preds = np.all((np.power(m_hat, 2) - m_hat) == 0)
+            binary_preds = (type_of_target(m_hat['preds']) == 'binary')
+            zero_one_preds = np.all((np.power(m_hat['preds'], 2) - m_hat['preds']) == 0)
             if binary_preds & zero_one_preds:
                 raise ValueError(f'For the binary treatment variable {self._dml_data.d_cols[self._i_treat]}, '
                                  f'predictions obtained with the ml_m learner {str(self._learner["ml_m"])} are also '
@@ -223,21 +225,25 @@ class DoubleMLPLR(DoubleML):
                                  'probabilities and not labels are predicted.')
 
         # an estimate of g is obtained for the IV-type score and callable scores
-        g_hat = None
+        g_hat = {'preds': None, 'models': None}
         if 'ml_g' in self._learner:
             # get an initial estimate for theta using the partialling out score
-            psi_a = -np.multiply(d - m_hat, d - m_hat)
-            psi_b = np.multiply(d - m_hat, y - l_hat)
+            psi_a = -np.multiply(d - m_hat['preds'], d - m_hat['preds'])
+            psi_b = np.multiply(d - m_hat['preds'], y - l_hat['preds'])
             theta_initial = -np.nanmean(psi_b) / np.nanmean(psi_a)
             # nuisance g
             g_hat = _dml_cv_predict(self._learner['ml_g'], x, y - theta_initial*d, smpls=smpls, n_jobs=n_jobs_cv,
-                                    est_params=self._get_params('ml_g'), method=self._predict_method['ml_g'])
-            _check_finite_predictions(g_hat, self._learner['ml_g'], 'ml_g', smpls)
+                                    est_params=self._get_params('ml_g'), method=self._predict_method['ml_g'],
+                                    return_models=return_models)
+            _check_finite_predictions(g_hat['preds'], self._learner['ml_g'], 'ml_g', smpls)
 
-        psi_a, psi_b = self._score_elements(y, d, l_hat, m_hat, g_hat, smpls)
-        preds = {'ml_l': l_hat,
-                 'ml_m': m_hat,
-                 'ml_g': g_hat}
+        psi_a, psi_b = self._score_elements(y, d, l_hat['preds'], m_hat['preds'], g_hat['preds'], smpls)
+        preds = {'predictions': {'ml_l': l_hat['preds'],
+                                 'ml_m': m_hat['preds'],
+                                 'ml_g': g_hat['preds']},
+                 'models': {'ml_l': l_hat['models'],
+                            'ml_m': m_hat['models'],
+                            'ml_g': g_hat['models']}}
 
         return psi_a, psi_b, preds
 

--- a/doubleml/tests/test_cv_predict.py
+++ b/doubleml/tests/test_cv_predict.py
@@ -69,7 +69,7 @@ def cv_predict_fixture(generate_data_cv_predict, cross_fit, params):
         preds = _dml_cv_predict(Lasso(), x, y, smpls, est_params=est_params, method=method)
         preds_ut = _dml_cv_predict_ut_version(Lasso(), x, y, smpls, est_params=est_params, method=method)
 
-    res_dict = {'preds': preds,
+    res_dict = {'preds': preds['preds'],
                 'preds_ut': preds_ut}
 
     return res_dict

--- a/doubleml/tests/test_doubleml_exceptions.py
+++ b/doubleml/tests/test_doubleml_exceptions.py
@@ -259,6 +259,9 @@ def test_doubleml_exception_fit():
     msg = 'store_predictions must be True or False. Got 1.'
     with pytest.raises(TypeError, match=msg):
         dml_plr.fit(store_predictions=1)
+    msg = 'store_models must be True or False. Got 1.'
+    with pytest.raises(TypeError, match=msg):
+        dml_plr.fit(store_models=1)
 
 
 @pytest.mark.ci


### PR DESCRIPTION
### Description
This PR implements the often requested feature to store the estimated models for nuisance parameters. To use it, call the method `fit()` with option `store_models=True`. Example:
```python
import numpy as np
import doubleml as dml
from doubleml.datasets import make_plr_CCDDHNR2018
from sklearn.ensemble import RandomForestRegressor
from sklearn.base import clone
np.random.seed(3141)
learner = RandomForestRegressor(n_estimators=100, max_features=20, max_depth=5, min_samples_leaf=2)
ml_g = learner
ml_m = learner
obj_dml_data = make_plr_CCDDHNR2018(alpha=0.5, n_obs=500, dim_x=20)
dml_plr_obj = dml.DoubleMLPLR(obj_dml_data, ml_g, ml_m)
dml_plr_obj.fit(store_models=True)
```

The estimated models can then be found in the attribute `dml_plr_obj.models`:
```
dml_plr_obj.models
{'ml_l': {'d': [[RandomForestRegressor(), RandomForestRegressor(), RandomForestRegressor(), RandomForestRegressor(), RandomForestRegressor()]]}, 'ml_m': {'d': [[RandomForestRegressor(), RandomForestRegressor(), RandomForestRegressor(), RandomForestRegressor(), RandomForestRegressor()]]}}
```
Note that the number of fitted models depends on the settings and the considered model. The outer dictionary contains one entry for each nuisance part (here `ml_l` and `ml_m`). For each nuisance part there is dictionary containing an entry for each treatment variable (here only `'d'`). The next inner part is a list of length `n_rep` (repeated cross-fitting) and then a list of length `n_folds` (number of folds per repeated cross fit).

### PR Checklist
- [x] The title of the pull request summarizes the changes made.
- [x] The PR contains a detailed description of all changes and additions.
- [x] The code passes all (unit) tests.
- [x] Enhancements or new feature are equipped with unit tests.
- [x] The changes adhere to the PEP8 standards.
