### PR TITLE
Bug fix: Overwrite for tune method (introduced for depreciation warning) did not return the tune result

### DIFF
--- a/doubleml/double_ml_pliv.py
+++ b/doubleml/double_ml_pliv.py
@@ -521,8 +521,10 @@ class DoubleMLPLIV(DoubleML):
                           DeprecationWarning, stacklevel=2)
             scoring_methods['ml_l'] = scoring_methods.pop('ml_g')
 
-        super(DoubleMLPLIV, self).tune(param_grids, tune_on_folds, scoring_methods, n_folds_tune, search_mode,
-                                       n_iter_randomized_search, n_jobs_cv, set_as_params, return_tune_res)
+        tune_res = super(DoubleMLPLIV, self).tune(param_grids, tune_on_folds, scoring_methods, n_folds_tune,
+                                                  search_mode, n_iter_randomized_search, n_jobs_cv, set_as_params,
+                                                  return_tune_res)
+        return tune_res
 
     def _nuisance_tuning_partial_x(self, smpls, param_grids, scoring_methods, n_folds_tune, n_jobs_cv,
                                    search_mode, n_iter_randomized_search):

--- a/doubleml/double_ml_plr.py
+++ b/doubleml/double_ml_plr.py
@@ -292,8 +292,9 @@ class DoubleMLPLR(DoubleML):
                           DeprecationWarning, stacklevel=2)
             scoring_methods['ml_l'] = scoring_methods.pop('ml_g')
 
-        super(DoubleMLPLR, self).tune(param_grids, tune_on_folds, scoring_methods, n_folds_tune, search_mode,
-                                      n_iter_randomized_search, n_jobs_cv, set_as_params, return_tune_res)
+        tune_res = super(DoubleMLPLR, self).tune(param_grids, tune_on_folds, scoring_methods, n_folds_tune, search_mode,
+                                                 n_iter_randomized_search, n_jobs_cv, set_as_params, return_tune_res)
+        return tune_res
 
     def _nuisance_tuning(self, smpls, param_grids, scoring_methods, n_folds_tune, n_jobs_cv,
                          search_mode, n_iter_randomized_search):

--- a/doubleml/tests/test_iivm_tune.py
+++ b/doubleml/tests/test_iivm_tune.py
@@ -94,7 +94,9 @@ def dml_iivm_fixture(generate_data_iivm, learner_g, learner_m, learner_r, score,
                                     subgroups=subgroups,
                                     dml_procedure=dml_procedure)
     # tune hyperparameters
-    _ = dml_iivm_obj.tune(par_grid, tune_on_folds=tune_on_folds, n_folds_tune=n_folds_tune)
+    tune_res = dml_iivm_obj.tune(par_grid, tune_on_folds=tune_on_folds, n_folds_tune=n_folds_tune,
+                                 return_tune_res=True)
+    assert isinstance(tune_res, list)
 
     dml_iivm_obj.fit()
 

--- a/doubleml/tests/test_irm_tune.py
+++ b/doubleml/tests/test_irm_tune.py
@@ -78,7 +78,9 @@ def dml_irm_fixture(generate_data_irm, learner_g, learner_m, score, dml_procedur
                                   dml_procedure=dml_procedure)
 
     # tune hyperparameters
-    _ = dml_irm_obj.tune(par_grid, tune_on_folds=tune_on_folds, n_folds_tune=n_folds_tune)
+    tune_res = dml_irm_obj.tune(par_grid, tune_on_folds=tune_on_folds, n_folds_tune=n_folds_tune,
+                                return_tune_res=False)
+    assert isinstance(tune_res, dml.DoubleMLIRM)
 
     dml_irm_obj.fit()
 

--- a/doubleml/tests/test_pliv_tune.py
+++ b/doubleml/tests/test_pliv_tune.py
@@ -96,7 +96,9 @@ def dml_pliv_fixture(generate_data_iv, learner_l, learner_m, learner_r, learner_
                                     dml_procedure=dml_procedure)
 
     # tune hyperparameters
-    _ = dml_pliv_obj.tune(par_grid, tune_on_folds=tune_on_folds, n_folds_tune=n_folds_tune)
+    tune_res = dml_pliv_obj.tune(par_grid, tune_on_folds=tune_on_folds, n_folds_tune=n_folds_tune,
+                                 return_tune_res=False)
+    assert isinstance(tune_res, dml.DoubleMLPLIV)
 
     dml_pliv_obj.fit()
 

--- a/doubleml/tests/test_plr_tune.py
+++ b/doubleml/tests/test_plr_tune.py
@@ -88,7 +88,9 @@ def dml_plr_fixture(generate_data2, learner_l, learner_m, learner_g, score, dml_
                                   dml_procedure=dml_procedure)
 
     # tune hyperparameters
-    _ = dml_plr_obj.tune(par_grid, tune_on_folds=tune_on_folds, n_folds_tune=n_folds_tune)
+    tune_res = dml_plr_obj.tune(par_grid, tune_on_folds=tune_on_folds, n_folds_tune=n_folds_tune,
+                                return_tune_res=True)
+    assert isinstance(tune_res, list)
 
     # fit with tuned parameters
     dml_plr_obj.fit()


### PR DESCRIPTION
### Description
- Bug fix: overwrite for tune method (introduced for depreciation warning) did not return the tune result.
- Some unit tests have been adapted to be sensitive for the bug, i.e., checking the return type.

### PR Checklist
- [x] The title of the pull request summarizes the changes made.
- [x] The PR contains a detailed description of all changes and additions.
- [x] The code passes all (unit) tests.
- [x] The changes adhere to the PEP8 standards.
