### PR TITLE
Fix unit tests

### DIFF
--- a/doubleml/tests/_utils_pliv_manual.py
+++ b/doubleml/tests/_utils_pliv_manual.py
@@ -91,8 +91,8 @@ def tune_nuisance_pliv(y, x, d, z, ml_l, ml_m, ml_r, ml_g, smpls, n_folds_tune,
             l_hat[train_index] = l_tune_res[idx].predict(x[train_index, :])
             m_hat[train_index] = m_tune_res[idx].predict(x[train_index, :])
             r_hat[train_index] = r_tune_res[idx].predict(x[train_index, :])
-        psi_a = -np.multiply(d - m_hat, d - m_hat)
-        psi_b = np.multiply(d - m_hat, y - l_hat)
+        psi_a = -np.multiply(d - r_hat, z - m_hat)
+        psi_b = np.multiply(z - m_hat, y - l_hat)
         theta_initial = -np.nanmean(psi_b) / np.nanmean(psi_a)
 
         g_tune_res = tune_grid_search(y - theta_initial*d, x, ml_g, smpls, param_grid_g, n_folds_tune)

--- a/doubleml/tests/test_doubleml_exceptions.py
+++ b/doubleml/tests/test_doubleml_exceptions.py
@@ -10,7 +10,7 @@ from sklearn.linear_model import Lasso, LogisticRegression
 from sklearn.base import BaseEstimator
 
 np.random.seed(3141)
-dml_data = make_plr_CCDDHNR2018(n_obs=50)
+dml_data = make_plr_CCDDHNR2018(n_obs=200)
 ml_l = Lasso()
 ml_m = Lasso()
 ml_g = Lasso()
@@ -18,13 +18,13 @@ ml_r = Lasso()
 dml_plr = DoubleMLPLR(dml_data, ml_l, ml_m)
 dml_plr_iv_type = DoubleMLPLR(dml_data, ml_l, ml_m, ml_g, score='IV-type')
 
-dml_data_pliv = make_pliv_CHS2015(n_obs=50, dim_z=1)
+dml_data_pliv = make_pliv_CHS2015(n_obs=200, dim_z=1)
 dml_pliv = DoubleMLPLIV(dml_data_pliv, ml_l, ml_m, ml_r)
 
-dml_data_irm = make_irm_data(n_obs=50)
-dml_data_iivm = make_iivm_data(n_obs=50)
+dml_data_irm = make_irm_data(n_obs=200)
+dml_data_iivm = make_iivm_data(n_obs=200)
 dml_cluster_data_pliv = make_pliv_multiway_cluster_CKMS2021(N=10, M=10)
-(x, y, d, z) = make_iivm_data(n_obs=50, return_type="array")
+(x, y, d, z) = make_iivm_data(n_obs=200, return_type="array")
 y[y > 0] = 1
 y[y < 0] = 0
 dml_data_irm_binary_outcome = DoubleMLData.from_arrays(x, y, d)


### PR DESCRIPTION
### Description
In this PR two unit tests have been fixed / adapted that failed in the recent release to `conda-forge`, see https://github.com/conda-forge/doubleml-feedstock/pull/9.
- Fixed a bug in the unit test computation of theta_initial for tuning of PLIV models with IV-type score
- increase the number of simulated observations to get more stable unit tests