### PR TITLE
A abstract base class for the data backends: DoubleMLBaseData

### DIFF
--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -119,16 +119,7 @@ class DoubleML(ABC):
     def __str__(self):
         class_name = self.__class__.__name__
         header = f'================== {class_name} Object ==================\n'
-        if self._is_cluster_data:
-            cluster_info = f'Cluster variable(s): {self._dml_data.cluster_cols}\n'
-        else:
-            cluster_info = ''
-        data_info = f'Outcome variable: {self._dml_data.y_col}\n' \
-                    f'Treatment variable(s): {self._dml_data.d_cols}\n' \
-                    f'Covariates: {self._dml_data.x_cols}\n' \
-                    f'Instrument variable(s): {self._dml_data.z_cols}\n' \
-                    + cluster_info +\
-                    f'No. Observations: {self._dml_data.n_obs}\n'
+        data_summary = self._dml_data.data_summary_str()
         score_info = f'Score function: {str(self.score)}\n' \
                      f'DML algorithm: {self.dml_procedure}\n'
         learner_info = ''
@@ -145,7 +136,7 @@ class DoubleML(ABC):
                               f'Apply cross-fitting: {self.apply_cross_fitting}\n'
         fit_summary = str(self.summary)
         res = header + \
-            '\n------------------ Data summary      ------------------\n' + data_info + \
+            '\n------------------ Data summary      ------------------\n' + data_summary + \
             '\n------------------ Score & algorithm ------------------\n' + score_info + \
             '\n------------------ Machine learner   ------------------\n' + learner_info + \
             '\n------------------ Resampling        ------------------\n' + resampling_info + \

--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -119,7 +119,7 @@ class DoubleML(ABC):
     def __str__(self):
         class_name = self.__class__.__name__
         header = f'================== {class_name} Object ==================\n'
-        data_summary = self._dml_data.data_summary_str()
+        data_summary = self._dml_data._data_summary_str()
         score_info = f'Score function: {str(self.score)}\n' \
                      f'DML algorithm: {self.dml_procedure}\n'
         learner_info = ''

--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -10,9 +10,12 @@ from statsmodels.stats.multitest import multipletests
 
 from abc import ABC, abstractmethod
 
-from .double_ml_data import DoubleMLData, DoubleMLClusterData
+from .double_ml_data import DoubleMLBaseData, DoubleMLClusterData
 from ._utils_resampling import DoubleMLResampling, DoubleMLClusterResampling
 from ._utils import _check_is_partition, _check_all_smpls, _check_smpl_split, _check_smpl_split_tpl, _draw_weights
+
+
+_implemented_data_backends = ['DoubleMLData', 'DoubleMLClusterData']
 
 
 class DoubleML(ABC):
@@ -28,8 +31,8 @@ class DoubleML(ABC):
                  draw_sample_splitting,
                  apply_cross_fitting):
         # check and pick up obj_dml_data
-        if not isinstance(obj_dml_data, DoubleMLData):
-            raise TypeError('The data must be of DoubleMLData type. '
+        if not isinstance(obj_dml_data, DoubleMLBaseData):
+            raise TypeError(f'The data must be of ' + ' or '.join(_implemented_data_backends) + ' type. '
                             f'{str(obj_dml_data)} of type {str(type(obj_dml_data))} was passed.')
         self._is_cluster_data = False
         if isinstance(obj_dml_data, DoubleMLClusterData):
@@ -940,33 +943,33 @@ class DoubleML(ABC):
         return learner_is_classifier
 
     def _initialize_arrays(self):
-        psi = np.full((self._dml_data.n_obs, self.n_rep, self._dml_data.n_treat), np.nan)
-        psi_a = np.full((self._dml_data.n_obs, self.n_rep, self._dml_data.n_treat), np.nan)
-        psi_b = np.full((self._dml_data.n_obs, self.n_rep, self._dml_data.n_treat), np.nan)
+        psi = np.full((self._dml_data.n_obs, self.n_rep, self._dml_data.n_coefs), np.nan)
+        psi_a = np.full((self._dml_data.n_obs, self.n_rep, self._dml_data.n_coefs), np.nan)
+        psi_b = np.full((self._dml_data.n_obs, self.n_rep, self._dml_data.n_coefs), np.nan)
 
-        coef = np.full(self._dml_data.n_treat, np.nan)
-        se = np.full(self._dml_data.n_treat, np.nan)
+        coef = np.full(self._dml_data.n_coefs, np.nan)
+        se = np.full(self._dml_data.n_coefs, np.nan)
 
-        all_coef = np.full((self._dml_data.n_treat, self.n_rep), np.nan)
-        all_se = np.full((self._dml_data.n_treat, self.n_rep), np.nan)
+        all_coef = np.full((self._dml_data.n_coefs, self.n_rep), np.nan)
+        all_se = np.full((self._dml_data.n_coefs, self.n_rep), np.nan)
 
         if self.dml_procedure == 'dml1':
             if self.apply_cross_fitting:
-                all_dml1_coef = np.full((self._dml_data.n_treat, self.n_rep, self.n_folds), np.nan)
+                all_dml1_coef = np.full((self._dml_data.n_coefs, self.n_rep, self.n_folds), np.nan)
             else:
-                all_dml1_coef = np.full((self._dml_data.n_treat, self.n_rep, 1), np.nan)
+                all_dml1_coef = np.full((self._dml_data.n_coefs, self.n_rep, 1), np.nan)
         else:
             all_dml1_coef = None
 
         return psi, psi_a, psi_b, coef, se, all_coef, all_se, all_dml1_coef
 
     def _initialize_boot_arrays(self, n_rep_boot):
-        boot_coef = np.full((self._dml_data.n_treat, n_rep_boot * self.n_rep), np.nan)
-        boot_t_stat = np.full((self._dml_data.n_treat, n_rep_boot * self.n_rep), np.nan)
+        boot_coef = np.full((self._dml_data.n_coefs, n_rep_boot * self.n_rep), np.nan)
+        boot_t_stat = np.full((self._dml_data.n_coefs, n_rep_boot * self.n_rep), np.nan)
         return n_rep_boot, boot_coef, boot_t_stat
 
     def _initialize_predictions(self):
-        self._predictions = {learner: np.full((self._dml_data.n_obs, self.n_rep, self._dml_data.n_treat), np.nan)
+        self._predictions = {learner: np.full((self._dml_data.n_obs, self.n_rep, self._dml_data.n_coefs), np.nan)
                              for learner in self.params_names}
 
     def _store_predictions(self, preds):

--- a/doubleml/double_ml_data.py
+++ b/doubleml/double_ml_data.py
@@ -24,7 +24,7 @@ class DoubleMLBaseData(ABC):
         self._data = data
 
     def __str__(self):
-        data_summary = self.data_summary_str()
+        data_summary = self._data_summary_str()
         buf = io.StringIO()
         self.data.info(verbose=False, buf=buf)
         df_info = buf.getvalue()
@@ -33,7 +33,7 @@ class DoubleMLBaseData(ABC):
               '\n------------------ DataFrame info    ------------------\n' + df_info
         return res
 
-    def data_summary_str(self):
+    def _data_summary_str(self):
         data_summary = f'No. Observations: {self.n_obs}\n'
         return data_summary
 
@@ -152,7 +152,7 @@ class DoubleMLData(DoubleMLBaseData):
         self.set_x_d(self.d_cols[0])
 
     def __str__(self):
-        data_summary = self.data_summary_str()
+        data_summary = self._data_summary_str()
         buf = io.StringIO()
         self.data.info(verbose=False, buf=buf)
         df_info = buf.getvalue()
@@ -161,7 +161,7 @@ class DoubleMLData(DoubleMLBaseData):
               '\n------------------ DataFrame info    ------------------\n' + df_info
         return res
 
-    def data_summary_str(self):
+    def _data_summary_str(self):
         data_summary = f'Outcome variable: {self.y_col}\n' \
                        f'Treatment variable(s): {self.d_cols}\n' \
                        f'Covariates: {self.x_cols}\n' \
@@ -653,7 +653,7 @@ class DoubleMLClusterData(DoubleMLData):
         self._check_disjoint_sets_cluster_cols()
 
     def __str__(self):
-        data_summary = self.data_summary_str()
+        data_summary = self._data_summary_str()
         buf = io.StringIO()
         self.data.info(verbose=False, buf=buf)
         df_info = buf.getvalue()
@@ -662,7 +662,7 @@ class DoubleMLClusterData(DoubleMLData):
               '\n------------------ DataFrame info    ------------------\n' + df_info
         return res
 
-    def data_summary_str(self):
+    def _data_summary_str(self):
         data_summary = f'Outcome variable: {self.y_col}\n' \
                        f'Treatment variable(s): {self.d_cols}\n' \
                        f'Cluster variable(s): {self.cluster_cols}\n' \

--- a/doubleml/double_ml_data.py
+++ b/doubleml/double_ml_data.py
@@ -44,11 +44,18 @@ class DoubleMLBaseData(ABC):
         """
         return self.data.shape[0]
 
-    # TODO: This property does not make sense but the base class DoubleML needs it (especially for the multiple
-    #  treatment variables case) and other things are also build around it, see for example DoubleML._params
+    # TODO: This and the following property does not make sense but the base class DoubleML needs it (especially for the
+    #  multiple treatment variables case) and other things are also build around it, see for example DoubleML._params
     @property
     def d_cols(self):
         return ['theta']
+
+    @property
+    def n_treat(self):
+        """
+        The number of treatment variables.
+        """
+        return 1
 
     @property
     @abstractmethod

--- a/doubleml/double_ml_data.py
+++ b/doubleml/double_ml_data.py
@@ -23,6 +23,20 @@ class DoubleMLBaseData(ABC):
                              'Contains duplicate column names.')
         self._data = data
 
+    def __str__(self):
+        data_summary = self.data_summary_str()
+        buf = io.StringIO()
+        self.data.info(verbose=False, buf=buf)
+        df_info = buf.getvalue()
+        res = '================== DoubleMLData Object ==================\n' + \
+              '\n------------------ Data summary      ------------------\n' + data_summary + \
+              '\n------------------ DataFrame info    ------------------\n' + df_info
+        return res
+
+    def data_summary_str(self):
+        data_summary = f'No. Observations: {self.n_obs}\n'
+        return data_summary
+
     @property
     def data(self):
         """
@@ -137,19 +151,13 @@ class DoubleMLData(DoubleMLBaseData):
         # by default, we initialize to the first treatment variable
         self.set_x_d(self.d_cols[0])
 
-    def __str__(self):
-        data_info = f'Outcome variable: {self.y_col}\n' \
-                    f'Treatment variable(s): {self.d_cols}\n' \
-                    f'Covariates: {self.x_cols}\n' \
-                    f'Instrument variable(s): {self.z_cols}\n' \
-                    f'No. Observations: {self.n_obs}\n'
-        buf = io.StringIO()
-        self.data.info(verbose=False, buf=buf)
-        df_info = buf.getvalue()
-        res = '================== DoubleMLData Object ==================\n' + \
-              '\n------------------ Data summary      ------------------\n' + data_info + \
-              '\n------------------ DataFrame info    ------------------\n' + df_info
-        return res
+    def data_summary_str(self):
+        data_summary = f'Outcome variable: {self.y_col}\n' \
+                       f'Treatment variable(s): {self.d_cols}\n' \
+                       f'Covariates: {self.x_cols}\n' \
+                       f'Instrument variable(s): {self.z_cols}\n' \
+                       f'No. Observations: {self.n_obs}\n'
+        return data_summary
 
     @classmethod
     def from_arrays(cls, x, y, d, z=None, use_other_treat_as_covariate=True,
@@ -634,20 +642,14 @@ class DoubleMLClusterData(DoubleMLData):
                               force_all_x_finite)
         self._check_disjoint_sets_cluster_cols()
 
-    def __str__(self):
-        data_info = f'Outcome variable: {self.y_col}\n' \
-                    f'Treatment variable(s): {self.d_cols}\n' \
-                    f'Cluster variable(s): {self.cluster_cols}\n' \
-                    f'Covariates: {self.x_cols}\n' \
-                    f'Instrument variable(s): {self.z_cols}\n' \
-                    f'No. Observations: {self.n_obs}\n'
-        buf = io.StringIO()
-        self.data.info(verbose=False, buf=buf)
-        df_info = buf.getvalue()
-        res = '================== DoubleMLClusterData Object ==================\n' + \
-              '\n------------------ Data summary      ------------------\n' + data_info + \
-              '\n------------------ DataFrame info    ------------------\n' + df_info
-        return res
+    def data_summary_str(self):
+        data_summary = f'Outcome variable: {self.y_col}\n' \
+                       f'Treatment variable(s): {self.d_cols}\n' \
+                       f'Cluster variable(s): {self.cluster_cols}\n' \
+                       f'Covariates: {self.x_cols}\n' \
+                       f'Instrument variable(s): {self.z_cols}\n' \
+                       f'No. Observations: {self.n_obs}\n'
+        return data_summary
 
     @classmethod
     def from_arrays(cls, x, y, d, cluster_vars, z=None, use_other_treat_as_covariate=True,

--- a/doubleml/double_ml_data.py
+++ b/doubleml/double_ml_data.py
@@ -44,6 +44,12 @@ class DoubleMLBaseData(ABC):
         """
         return self.data.shape[0]
 
+    # TODO: This property does not make sense but the base class DoubleML needs it (especially for the multiple
+    #  treatment variables case) and other things are also build around it, see for example DoubleML._params
+    @property
+    def d_cols(self):
+        return ['theta']
+
     @property
     @abstractmethod
     def n_coefs(self):

--- a/doubleml/double_ml_data.py
+++ b/doubleml/double_ml_data.py
@@ -28,7 +28,7 @@ class DoubleMLBaseData(ABC):
         buf = io.StringIO()
         self.data.info(verbose=False, buf=buf)
         df_info = buf.getvalue()
-        res = '================== DoubleMLData Object ==================\n' + \
+        res = '================== DoubleMLBaseData Object ==================\n' + \
               '\n------------------ Data summary      ------------------\n' + data_summary + \
               '\n------------------ DataFrame info    ------------------\n' + df_info
         return res
@@ -150,6 +150,16 @@ class DoubleMLData(DoubleMLBaseData):
         self._set_y_z()
         # by default, we initialize to the first treatment variable
         self.set_x_d(self.d_cols[0])
+
+    def __str__(self):
+        data_summary = self.data_summary_str()
+        buf = io.StringIO()
+        self.data.info(verbose=False, buf=buf)
+        df_info = buf.getvalue()
+        res = '================== DoubleMLData Object ==================\n' + \
+              '\n------------------ Data summary      ------------------\n' + data_summary + \
+              '\n------------------ DataFrame info    ------------------\n' + df_info
+        return res
 
     def data_summary_str(self):
         data_summary = f'Outcome variable: {self.y_col}\n' \
@@ -641,6 +651,16 @@ class DoubleMLClusterData(DoubleMLData):
                               use_other_treat_as_covariate,
                               force_all_x_finite)
         self._check_disjoint_sets_cluster_cols()
+
+    def __str__(self):
+        data_summary = self.data_summary_str()
+        buf = io.StringIO()
+        self.data.info(verbose=False, buf=buf)
+        df_info = buf.getvalue()
+        res = '================== DoubleMLClusterData Object ==================\n' + \
+              '\n------------------ Data summary      ------------------\n' + data_summary + \
+              '\n------------------ DataFrame info    ------------------\n' + df_info
+        return res
 
     def data_summary_str(self):
         data_summary = f'Outcome variable: {self.y_col}\n' \

--- a/doubleml/double_ml_iivm.py
+++ b/doubleml/double_ml_iivm.py
@@ -3,6 +3,7 @@ from sklearn.utils import check_X_y
 from sklearn.utils.multiclass import type_of_target
 
 from .double_ml import DoubleML
+from .double_ml_data import DoubleMLData
 from ._utils import _dml_cv_predict, _get_cond_smpls, _dml_tune, _check_finite_predictions
 
 
@@ -198,6 +199,9 @@ class DoubleMLIIVM(DoubleML):
         return
 
     def _check_data(self, obj_dml_data):
+        if not isinstance(obj_dml_data, DoubleMLData):
+            raise TypeError('The data must be of DoubleMLData type. '
+                            f'{str(obj_dml_data)} of type {str(type(obj_dml_data))} was passed.')
         one_treat = (obj_dml_data.n_treat == 1)
         binary_treat = (type_of_target(obj_dml_data.d) == 'binary')
         zero_one_treat = np.all((np.power(obj_dml_data.d, 2) - obj_dml_data.d) == 0)

--- a/doubleml/double_ml_irm.py
+++ b/doubleml/double_ml_irm.py
@@ -3,6 +3,7 @@ from sklearn.utils import check_X_y
 from sklearn.utils.multiclass import type_of_target
 
 from .double_ml import DoubleML
+from .double_ml_data import DoubleMLData
 from ._utils import _dml_cv_predict, _get_cond_smpls, _dml_tune, _check_finite_predictions
 
 
@@ -158,6 +159,9 @@ class DoubleMLIRM(DoubleML):
         return
 
     def _check_data(self, obj_dml_data):
+        if not isinstance(obj_dml_data, DoubleMLData):
+            raise TypeError('The data must be of DoubleMLData type. '
+                            f'{str(obj_dml_data)} of type {str(type(obj_dml_data))} was passed.')
         if obj_dml_data.z_cols is not None:
             raise ValueError('Incompatible data. ' +
                              ' and '.join(obj_dml_data.z_cols) +

--- a/doubleml/double_ml_pliv.py
+++ b/doubleml/double_ml_pliv.py
@@ -6,6 +6,7 @@ from sklearn.linear_model import LinearRegression
 from sklearn.dummy import DummyRegressor
 
 from .double_ml import DoubleML
+from .double_ml_data import DoubleMLData
 from ._utils import _dml_cv_predict, _dml_tune, _check_finite_predictions
 
 
@@ -248,6 +249,9 @@ class DoubleMLPLIV(DoubleML):
         return score
 
     def _check_data(self, obj_dml_data):
+        if not isinstance(obj_dml_data, DoubleMLData):
+            raise TypeError('The data must be of DoubleMLData type. '
+                            f'{str(obj_dml_data)} of type {str(type(obj_dml_data))} was passed.')
         if obj_dml_data.n_instr == 0:
             raise ValueError('Incompatible data. ' +
                              'At least one variable must be set as instrumental variable. '

--- a/doubleml/double_ml_plr.py
+++ b/doubleml/double_ml_plr.py
@@ -3,6 +3,7 @@ from sklearn.utils import check_X_y
 from sklearn.utils.multiclass import type_of_target
 
 from .double_ml import DoubleML
+from .double_ml_data import DoubleMLData
 from ._utils import _dml_cv_predict, _dml_tune, _check_finite_predictions
 
 
@@ -131,6 +132,9 @@ class DoubleMLPLR(DoubleML):
         return
 
     def _check_data(self, obj_dml_data):
+        if not isinstance(obj_dml_data, DoubleMLData):
+            raise TypeError('The data must be of DoubleMLData type. '
+                            f'{str(obj_dml_data)} of type {str(type(obj_dml_data))} was passed.')
         if obj_dml_data.z_cols is not None:
             raise ValueError('Incompatible data. ' +
                              ' and '.join(obj_dml_data.z_cols) +

--- a/doubleml/tests/test_doubleml_exceptions.py
+++ b/doubleml/tests/test_doubleml_exceptions.py
@@ -5,6 +5,7 @@ import numpy as np
 from doubleml import DoubleMLPLR, DoubleMLIRM, DoubleMLIIVM, DoubleMLPLIV, DoubleMLData, DoubleMLClusterData
 from doubleml.datasets import make_plr_CCDDHNR2018, make_irm_data, make_pliv_CHS2015, make_iivm_data,\
     make_pliv_multiway_cluster_CKMS2021
+from doubleml.double_ml_data import DoubleMLBaseData
 
 from sklearn.linear_model import Lasso, LogisticRegression
 from sklearn.base import BaseEstimator
@@ -27,11 +28,32 @@ dml_data_irm_binary_outcome = DoubleMLData.from_arrays(x, y, d)
 dml_data_iivm_binary_outcome = DoubleMLData.from_arrays(x, y, d, z)
 
 
+class DummyDataClass(DoubleMLBaseData):
+    def __init__(self,
+                 data):
+        DoubleMLBaseData.__init__(self, data)
+
+    @property
+    def n_coefs(self):
+        return 1
+
+
 @pytest.mark.ci
 def test_doubleml_exception_data():
-    msg = 'The data must be of DoubleMLData type.'
+    msg = 'The data must be of DoubleMLData or DoubleMLClusterData type.'
     with pytest.raises(TypeError, match=msg):
         _ = DoubleMLPLR(pd.DataFrame(), ml_g, ml_m)
+
+    msg = 'The data must be of DoubleMLData type.'
+    with pytest.raises(TypeError, match=msg):
+        _ = DoubleMLPLR(DummyDataClass(pd.DataFrame(np.zeros((100, 10)))), ml_g, ml_m)
+    with pytest.raises(TypeError, match=msg):
+        _ = DoubleMLPLR(DummyDataClass(pd.DataFrame(np.zeros((100, 10)))), ml_g, ml_m)
+    with pytest.raises(TypeError, match=msg):
+        _ = DoubleMLPLR(DummyDataClass(pd.DataFrame(np.zeros((100, 10)))), ml_g, ml_m)
+    with pytest.raises(TypeError, match=msg):
+        _ = DoubleMLIIVM(DummyDataClass(pd.DataFrame(np.zeros((100, 10)))),
+                         Lasso(), LogisticRegression(), LogisticRegression())
 
     # PLR with IV
     msg = (r'Incompatible data. Z1 have been set as instrumental variable\(s\). '


### PR DESCRIPTION
### Description
This PR introduces a new abstract base class `DoubleMLBaseData` The goal is to disentangle the basic data handling, from the handling of the causal model (i.e. which variable is the treatment variable etc.). 

### Comments
The overall goal is to make it easier to write new data backends. Note however that the handling of the multiple treatment case is currently a pretty fundamental / core part of the implementation of the base class `DoubleML`. Therefore, it wasn't yet possible to completely get rid of properties like `d_cols` or `n_treats` in the base class `DoubleMLBaseData`.

### PR Checklist

- [ ] The title of the pull request summarizes the changes made.
- [ ] The PR contains a detailed description of all changes and additions.
- [ ] The code passes all (unit) tests.
- [ ] Enhancements or new feature are equipped with unit tests.
- [ ] The changes adhere to the PEP8 standards.
