### PR TITLE
Remove workflow for Python 3.6

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,7 +22,6 @@ jobs:
     strategy:
       matrix:
         config:
-          - {os: 'ubuntu-latest', python-version: '3.6'}
           - {os: 'ubuntu-latest', python-version: '3.7'}
           - {os: 'ubuntu-latest', python-version: '3.8'}
           - {os: 'windows-latest', python-version: '3.8'}


### PR DESCRIPTION
drop python version 3.6. from pytest.yml