### PR TITLE
Fix for [Bug]: KeyError in DoubleMLPLIV.fit() with multiple instruments and store_predictions=True

### DIFF
--- a/doubleml/double_ml_pliv.py
+++ b/doubleml/double_ml_pliv.py
@@ -394,15 +394,28 @@ class DoubleMLPLIV(LinearScoreMixin, DoubleML):
                                             smpls)
         psi_elements = {'psi_a': psi_a,
                         'psi_b': psi_b}
-        preds = {'predictions': {'ml_l': l_hat['preds'],
-                                 'ml_m': m_hat['preds'],
-                                 'ml_r': r_hat['preds'],
-                                 'ml_g': g_hat['preds']},
-                 'models': {'ml_l': l_hat['models'],
-                            'ml_m': m_hat['models'],
-                            'ml_r': r_hat['models'],
-                            'ml_g': g_hat['models']}
-                 }
+        if self._dml_data.n_instr == 1:
+            # one instrument: just identified
+            preds = {'predictions': {'ml_l': l_hat['preds'],
+                                    'ml_m': m_hat['preds'],
+                                    'ml_r': r_hat['preds'],
+                                    'ml_g': g_hat['preds']},
+                    'models': {'ml_l': l_hat['models'],
+                                'ml_m': m_hat['models'],
+                                'ml_r': r_hat['models'],
+                                'ml_g': g_hat['models']}
+                    }
+        else:
+            # several instruments: 2SLS
+            preds = {'predictions': {'ml_l': l_hat['preds'],
+                                    'ml_m': m_hat['preds'],
+                                    'ml_r': r_hat['preds'],
+                                    'ml_g': g_hat['preds']} | {f"ml_m_{z_col}": m_hat['preds'][:, i_instr] for (z_col, i_instr) in zip(self._dml_data.z_cols, range(self._dml_data.n_instr))},
+                    'models': {'ml_l': l_hat['models'],
+                                'ml_m': m_hat['models'],
+                                'ml_r': r_hat['models'],
+                                'ml_g': g_hat['models']} | {f"ml_m_{z_col}": m_hat['models'][i_instr] for (z_col, i_instr) in zip(self._dml_data.z_cols, range(self._dml_data.n_instr))}
+                    }
 
         return psi_elements, preds
 


### PR DESCRIPTION
### Description
In the case of multiple instruments, the function DoubleMLPLIV.fit() throws an error when executed with the parameter 'store_predictions=True', as reported in [Bug]: KeyError in DoubleMLPLIV.fit() with multiple instruments and store_predictions=True.

This occurs because the list of learner names is defined as follows in the case of multiple instruments:

`line 269 in double_ml_pliv.py: param_names = ['ml_l', 'ml_r'] + ['ml_m_' + z_col for z_col in self._dml_data.z_cols]`

The predictions for the nuisance functions are however saved using the keys 'ml_l', 'ml_m', 'ml_r', 'ml_g'.

```
line 397 - 405 in double_ml_pliv.py: 
        preds = {'predictions': {'ml_l': l_hat['preds'],
                                 'ml_m': m_hat['preds'],
                                 'ml_r': r_hat['preds'],
                                 'ml_g': g_hat['preds']},
                 'models': {'ml_l': l_hat['models'],
                            'ml_m': m_hat['models'],
                            'ml_r': r_hat['models'],
                            'ml_g': g_hat['models']}
                 }

```

To store the predictions if store_predictions=True in DoubleMLPLIV.fit(), we use preds['predictions'] but iterate over param_names. Hence, the reported KeyError occurred.

To solve this error, I propose to add the predictions and models made for each instrument in the case of multiple instruments, i.e. for the list of learners

`['ml_m_' + z_col for z_col in self._dml_data.z_cols]`,

to the dictionaries preds['predictions'] and preds['models'], respectively.
The proposed code passes all (unit) tests.

### Reference to Issues or PRs
[Bug]: KeyError in DoubleMLPLIV.fit() with multiple instruments and store_predictions=True #184 
