### PR TITLE
fix targets, rmse calculation and learner evaluation  + add stratification for IRM and IIVM models 

### DIFF
--- a/doubleml/_utils.py
+++ b/doubleml/_utils.py
@@ -6,6 +6,7 @@ from sklearn.base import clone
 from sklearn.preprocessing import LabelEncoder
 from sklearn.model_selection import KFold
 from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
+from sklearn.metrics import mean_squared_error
 
 from joblib import Parallel, delayed
 
@@ -111,7 +112,7 @@ def _dml_cv_predict(estimator, x, y, smpls=None,
             res['preds'] = preds[:, 1]
         else:
             res['preds'] = preds
-        res['targets'] = y
+        res['targets'] = np.copy(y)
     else:
         if not smpls_is_partition:
             assert not fold_specific_target, 'combination of fold-specific y and no cross-fitting not implemented yet'
@@ -235,3 +236,9 @@ def _check_is_propensity(preds, learner, learner_name, smpls, eps=1e-12):
         warnings.warn(f'Propensity predictions from learner {str(learner)} for'
                       f' {learner_name} are close to zero or one (eps={eps}).')
     return
+
+
+def _rmse(y_true, y_pred):
+    subset = np.logical_not(np.isnan(y_true))
+    rmse = mean_squared_error(y_true[subset], y_pred[subset], squared=False)
+    return rmse

--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -87,6 +87,8 @@ class DoubleML(ABC):
             self._n_folds = n_folds
         self._n_rep = n_rep
         self._apply_cross_fitting = apply_cross_fitting
+        # default is no stratification
+        self._strata = None
 
         # check and set dml_procedure and score
         if (not isinstance(dml_procedure, str)) | (dml_procedure not in ['dml1', 'dml2']):
@@ -1139,7 +1141,8 @@ class DoubleML(ABC):
             obj_dml_resampling = DoubleMLResampling(n_folds=self.n_folds,
                                                     n_rep=self.n_rep,
                                                     n_obs=self._dml_data.n_obs,
-                                                    apply_cross_fitting=self.apply_cross_fitting)
+                                                    apply_cross_fitting=self.apply_cross_fitting,
+                                                    stratify=self._strata)
             self._smpls = obj_dml_resampling.split_samples()
 
         return self

--- a/doubleml/double_ml_iivm.py
+++ b/doubleml/double_ml_iivm.py
@@ -142,6 +142,8 @@ class DoubleMLIIVM(LinearScoreMixin, DoubleML):
 
         self._check_data(self._dml_data)
         self._check_score(self.score)
+        # set stratication for resampling
+        self._stratify = self._dml_data.d
         ml_g_is_classifier = self._check_learner(ml_g, 'ml_g', regressor=True, classifier=True)
         _ = self._check_learner(ml_m, 'ml_m', regressor=False, classifier=True)
         _ = self._check_learner(ml_r, 'ml_r', regressor=False, classifier=True)

--- a/doubleml/double_ml_iivm.py
+++ b/doubleml/double_ml_iivm.py
@@ -143,7 +143,7 @@ class DoubleMLIIVM(LinearScoreMixin, DoubleML):
         self._check_data(self._dml_data)
         self._check_score(self.score)
         # set stratication for resampling
-        self._stratify = self._dml_data.d
+        self._strata = self._dml_data.d.reshape(-1, 1) + 2 * self._dml_data.z.reshape(-1, 1)
         ml_g_is_classifier = self._check_learner(ml_g, 'ml_g', regressor=True, classifier=True)
         _ = self._check_learner(ml_m, 'ml_m', regressor=False, classifier=True)
         _ = self._check_learner(ml_r, 'ml_r', regressor=False, classifier=True)

--- a/doubleml/double_ml_iivm.py
+++ b/doubleml/double_ml_iivm.py
@@ -241,6 +241,8 @@ class DoubleMLIIVM(LinearScoreMixin, DoubleML):
                                  est_params=self._get_params('ml_g0'), method=self._predict_method['ml_g'],
                                  return_models=return_models)
         _check_finite_predictions(g_hat0['preds'], self._learner['ml_g'], 'ml_g', smpls)
+        # adjust target values to consider only compatible subsamples
+        g_hat0['targets'][z == 0] = np.nan
 
         if self._dml_data.binary_outcome:
             binary_preds = (type_of_target(g_hat0['preds']) == 'binary')
@@ -257,6 +259,8 @@ class DoubleMLIIVM(LinearScoreMixin, DoubleML):
                                  est_params=self._get_params('ml_g1'), method=self._predict_method['ml_g'],
                                  return_models=return_models)
         _check_finite_predictions(g_hat1['preds'], self._learner['ml_g'], 'ml_g', smpls)
+        # adjust target values to consider only compatible subsamples
+        g_hat1['targets'][z == 1] = np.nan
 
         if self._dml_data.binary_outcome:
             binary_preds = (type_of_target(g_hat1['preds']) == 'binary')
@@ -284,6 +288,8 @@ class DoubleMLIIVM(LinearScoreMixin, DoubleML):
         else:
             r_hat0 = {'preds': np.zeros_like(d), 'targets': np.zeros_like(d), 'models': None}
         _check_finite_predictions(r_hat0['preds'], self._learner['ml_r'], 'ml_r', smpls)
+        # adjust target values to consider only compatible subsamples
+        r_hat0['targets'][z == 0] = np.nan
 
         if self.subgroups['never_takers']:
             r_hat1 = _dml_cv_predict(self._learner['ml_r'], x, d, smpls=smpls_z1, n_jobs=n_jobs_cv,
@@ -292,6 +298,8 @@ class DoubleMLIIVM(LinearScoreMixin, DoubleML):
         else:
             r_hat1 = {'preds': np.ones_like(d), 'targets': np.ones_like(d), 'models': None}
         _check_finite_predictions(r_hat1['preds'], self._learner['ml_r'], 'ml_r', smpls)
+        # adjust target values to consider only compatible subsamples
+        r_hat1['targets'][z == 1] = np.nan
 
         psi_a, psi_b = self._score_elements(y, z, d,
                                             g_hat0['preds'], g_hat1['preds'], m_hat['preds'],

--- a/doubleml/double_ml_irm.py
+++ b/doubleml/double_ml_irm.py
@@ -196,6 +196,8 @@ class DoubleMLIRM(LinearScoreMixin, DoubleML):
                                  est_params=self._get_params('ml_g0'), method=self._predict_method['ml_g'],
                                  return_models=return_models)
         _check_finite_predictions(g_hat0['preds'], self._learner['ml_g'], 'ml_g', smpls)
+        # adjust target values to consider only compatible subsamples
+        g_hat0['targets'][d == 1] = np.nan
 
         if self._dml_data.binary_outcome:
             binary_preds = (type_of_target(g_hat0['preds']) == 'binary')
@@ -212,6 +214,8 @@ class DoubleMLIRM(LinearScoreMixin, DoubleML):
                                      est_params=self._get_params('ml_g1'), method=self._predict_method['ml_g'],
                                      return_models=return_models)
             _check_finite_predictions(g_hat1['preds'], self._learner['ml_g'], 'ml_g', smpls)
+            # adjust target values to consider only compatible subsamples
+            g_hat1['targets'][d == 0] = np.nan
 
             if self._dml_data.binary_outcome:
                 binary_preds = (type_of_target(g_hat1['preds']) == 'binary')

--- a/doubleml/double_ml_irm.py
+++ b/doubleml/double_ml_irm.py
@@ -127,6 +127,8 @@ class DoubleMLIRM(LinearScoreMixin, DoubleML):
 
         self._check_data(self._dml_data)
         self._check_score(self.score)
+        # set stratication for resampling
+        self._strata = self._dml_data.d
         ml_g_is_classifier = self._check_learner(ml_g, 'ml_g', regressor=True, classifier=True)
         _ = self._check_learner(ml_m, 'ml_m', regressor=False, classifier=True)
         self._learner = {'ml_g': ml_g, 'ml_m': ml_m}

--- a/doubleml/tests/_utils.py
+++ b/doubleml/tests/_utils.py
@@ -1,14 +1,18 @@
 import numpy as np
-from sklearn.model_selection import KFold, GridSearchCV
+from sklearn.model_selection import KFold, GridSearchCV, StratifiedKFold
 from sklearn.base import clone
 
 
-def draw_smpls(n_obs, n_folds, n_rep=1):
+def draw_smpls(n_obs, n_folds, n_rep=1, groups=None):
     all_smpls = []
     for _ in range(n_rep):
-        resampling = KFold(n_splits=n_folds,
-                           shuffle=True)
-        smpls = [(train, test) for train, test in resampling.split(np.zeros(n_obs))]
+        if groups is None:
+            resampling = KFold(n_splits=n_folds,
+                               shuffle=True)
+        else:
+            resampling = StratifiedKFold(n_splits=n_folds,
+                                         shuffle=True)
+        smpls = [(train, test) for train, test in resampling.split(X=np.zeros(n_obs), y=groups)]
         all_smpls.append(smpls)
     return all_smpls
 

--- a/doubleml/tests/_utils_irm_manual.py
+++ b/doubleml/tests/_utils_irm_manual.py
@@ -4,6 +4,8 @@ from sklearn.base import clone, is_classifier
 from ._utils_boot import boot_manual, draw_weights
 from ._utils import fit_predict, fit_predict_proba, tune_grid_search
 
+from .._utils import _check_is_propensity
+
 
 def fit_irm(y, x, d,
             learner_g, learner_m, all_smpls, dml_procedure, score,
@@ -127,6 +129,7 @@ def compute_iivm_residuals(y, g_hat0_list, g_hat1_list, m_hat_list, p_hat_list, 
         m_hat[test_index] = m_hat_list[idx]
         p_hat[test_index] = p_hat_list[idx]
 
+    _check_is_propensity(m_hat, 'learner_m', 'ml_m', smpls, eps=1e-12)
     return u_hat0, u_hat1, g_hat0, g_hat1, m_hat, p_hat
 
 

--- a/doubleml/tests/test_irm.py
+++ b/doubleml/tests/test_irm.py
@@ -18,8 +18,8 @@ from ._utils_irm_manual import fit_irm, boot_irm
 @pytest.fixture(scope='module',
                 params=[[LinearRegression(),
                          LogisticRegression(solver='lbfgs', max_iter=250)],
-                        [RandomForestRegressor(max_depth=2, n_estimators=10),
-                         RandomForestClassifier(max_depth=2, n_estimators=10)]])
+                        [RandomForestRegressor(max_depth=5, n_estimators=10),
+                         RandomForestClassifier(max_depth=5, n_estimators=10)]])
 def learner(request):
     return request.param
 
@@ -56,20 +56,24 @@ def dml_irm_fixture(generate_data_irm, learner, score, dml_procedure, trimming_t
     ml_m = clone(learner[1])
 
     np.random.seed(3141)
+    n_obs = len(y)
+    all_smpls = draw_smpls(n_obs, n_folds, n_rep=1, groups=d)
     obj_dml_data = dml.DoubleMLData.from_arrays(x, y, d)
+
+    np.random.seed(3141)
     dml_irm_obj = dml.DoubleMLIRM(obj_dml_data,
                                   ml_g, ml_m,
                                   n_folds,
                                   score=score,
                                   dml_procedure=dml_procedure,
+                                  draw_sample_splitting=False,
                                   trimming_threshold=trimming_threshold)
 
+    # synchronize the sample splitting
+    dml_irm_obj.set_sample_splitting(all_smpls=all_smpls)
     dml_irm_obj.fit()
 
     np.random.seed(3141)
-    n_obs = len(y)
-    all_smpls = draw_smpls(n_obs, n_folds)
-
     res_manual = fit_irm(y, x, d,
                          clone(learner[0]), clone(learner[1]),
                          all_smpls, dml_procedure, score, trimming_threshold=trimming_threshold)


### PR DESCRIPTION
Fix the `nuisance_targets` for IRM and IIVM models.
The target values for conditional response surfaces are only partly observable e.g. for `ml_g0` only the values of `y` with `d==0` are the relevant targets. The other target values are now set to `np.nan`. 
The method `evaluate_learner` is adjusted to ignore `nan` values. This has to be considered for custom metrics (documentation is updated).

Further, stratified resampling is implemented for `IRM` and `IIVM` models.
In the `DoubleMLResampling` class now accepts `stratify` as input which should correspond to a stratification vector. If `stratify=None` (default and used for e.g. `PLR`) this is ignored. For `IRM` and `IIVM` the resampling will now be stratified and with respect to the treatment and instrument. 

Reference to Issues
#187 

- [x] The title of the pull request summarizes the changes made.
- [x] The PR contains a detailed description of all changes and additions.
- [x] References to related issues or PRs are added.
- [x] The code passes all (unit) tests.
- [x] Enhancements or new feature are equipped with unit tests.
- [x] The changes adhere to the PEP8 standards.
