### PR TITLE
Add clustering for nonlinear scores

### DIFF
--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -1300,7 +1300,16 @@ class DoubleML(ABC):
         smpls = self.__smpls
 
         if not self._is_cluster_data:
-            coef, dml1_coefs = self._est_coef(psi_elements, dml_procedure, smpls,)
+            if dml_procedure == 'dml1':
+                # Note that len(smpls) is only not equal to self.n_folds if self.apply_cross_fitting = False
+                dml1_coefs = np.zeros(len(smpls))
+                for idx, (_, test_index) in enumerate(smpls):
+                    dml1_coefs[idx] = self._est_coef(psi_elements, test_index)
+                coef = np.mean(dml1_coefs)
+            else:
+                assert dml_procedure == 'dml2'
+                dml1_coefs = None
+                coef = self._est_coef(psi_elements)
         else:
             smpls_cluster = self.__smpls_cluster
             coef, dml1_coefs = self._est_coef_cluster_data(psi_elements, dml_procedure, smpls, smpls_cluster)

--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -1458,7 +1458,7 @@ class DoubleML(ABC):
         return sigma2_hat
 
     @abstractmethod
-    def _est_coef(self, psi_elements, inds=None):
+    def _est_coef(self, psi_elements, smpls, scaling_factor=None, inds=None):
         pass
 
     @property

--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -1304,12 +1304,18 @@ class DoubleML(ABC):
                 # Note that len(smpls) is only not equal to self.n_folds if self.apply_cross_fitting = False
                 dml1_coefs = np.zeros(len(smpls))
                 for idx, (_, test_index) in enumerate(smpls):
-                    dml1_coefs[idx] = self._est_coef(psi_elements, test_index)
+                    scaling_factor = 1./len(test_index)
+                    dml1_coefs[idx] = self._est_coef(psi_elements, scaling_factor=scaling_factor, inds=test_index)
                 coef = np.mean(dml1_coefs)
             else:
                 assert dml_procedure == 'dml2'
                 dml1_coefs = None
-                coef = self._est_coef(psi_elements)
+                # calculate scaling based on number of test samples (usually this should be equal to n_obs)
+                n_samples = 0
+                for (_, test_index) in smpls:
+                    n_samples += len(test_index)
+                scaling_factor = 1./n_samples
+                coef = self._est_coef(psi_elements, scaling_factor=scaling_factor)
         else:
             smpls_cluster = self.__smpls_cluster
             coef, dml1_coefs = self._est_coef_cluster_data(psi_elements, dml_procedure, smpls, smpls_cluster)

--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -1300,16 +1300,7 @@ class DoubleML(ABC):
         smpls = self.__smpls
 
         if not self._is_cluster_data:
-            if dml_procedure == 'dml1':
-                # Note that len(smpls) is only not equal to self.n_folds if self.apply_cross_fitting = False
-                dml1_coefs = np.zeros(len(smpls))
-                for idx, (_, test_index) in enumerate(smpls):
-                    dml1_coefs[idx] = self._est_coef(psi_elements, test_index)
-                coef = np.mean(dml1_coefs)
-            else:
-                assert dml_procedure == 'dml2'
-                dml1_coefs = None
-                coef = self._est_coef(psi_elements)
+            coef, dml1_coefs = self._est_coef(psi_elements, dml_procedure, smpls,)
         else:
             smpls_cluster = self.__smpls_cluster
             coef, dml1_coefs = self._est_coef_cluster_data(psi_elements, dml_procedure, smpls, smpls_cluster)

--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -1463,7 +1463,7 @@ class DoubleML(ABC):
         return sigma2_hat
 
     @abstractmethod
-    def _est_coef(self, psi_elements, smpls, scaling_factor=None, inds=None):
+    def _est_coef(self, psi_elements, smpls=None, scaling_factor=None, inds=None):
         pass
 
     @property

--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -1308,13 +1308,13 @@ class DoubleML(ABC):
             # Note that len(smpls) is only not equal to self.n_folds if self.apply_cross_fitting = False
             dml1_coefs = np.zeros(len(smpls))
             for idx, (_, test_index) in enumerate(smpls):
-                dml1_coefs[idx] = self._est_coef(psi_elements, smpls=smpls, inds=test_index)
+                dml1_coefs[idx] = self._est_coef(psi_elements, inds=test_index)
             coef = np.mean(dml1_coefs)
         else:
             assert dml_procedure == 'dml2'
             dml1_coefs = None
             if not self._is_cluster_data:
-                coef = self._est_coef(psi_elements, smpls=smpls)
+                coef = self._est_coef(psi_elements)
             else:
                 scaling_factor = [1.] * len(smpls)
                 for i_fold, (_, test_index) in enumerate(smpls):

--- a/doubleml/double_ml_score_mixins.py
+++ b/doubleml/double_ml_score_mixins.py
@@ -39,14 +39,13 @@ class LinearScoreMixin:
     def _compute_score_deriv(self, psi_elements, coef):
         return psi_elements['psi_a']
 
-    def _est_coef(self, psi_elements, inds=None):
+    def _est_coef(self, psi_elements, scaling_factor, inds=None):
         psi_a = psi_elements['psi_a']
         psi_b = psi_elements['psi_b']
         if inds is not None:
             psi_a = psi_a[inds]
             psi_b = psi_b[inds]
         
-        scaling_factor = 1./len(psi_a)
         coef = - (scaling_factor * np.sum(psi_b)) / (scaling_factor * np.sum(psi_a))
         return coef
 
@@ -114,18 +113,18 @@ class NonLinearScoreMixin:
     def _compute_score_deriv(self, psi_elements, coef):
         pass
 
-    def _est_coef(self, psi_elements, inds=None):
+    def _est_coef(self, psi_elements, scaling_factor, inds=None):
         if inds is not None:
             psi_elements = copy.deepcopy(psi_elements)
             for key, value in psi_elements.items():
                 psi_elements[key] = value[inds]
 
         def score(theta):
-            res = np.mean(self._compute_score(psi_elements, theta))
+            res = scaling_factor * np.sum(self._compute_score(psi_elements, theta))
             return res
 
         def score_deriv(theta):
-            res = np.mean(self._compute_score_deriv(psi_elements, theta))
+            res = scaling_factor * np.sum(self._compute_score_deriv(psi_elements, theta))
             return res
 
         if self._coef_bounds is None:

--- a/doubleml/double_ml_score_mixins.py
+++ b/doubleml/double_ml_score_mixins.py
@@ -209,4 +209,3 @@ class NonLinearScoreMixin:
                                       'No theta found such that the score function evaluates to a positive value.')
 
         return theta_hat
-

--- a/doubleml/double_ml_score_mixins.py
+++ b/doubleml/double_ml_score_mixins.py
@@ -39,27 +39,16 @@ class LinearScoreMixin:
     def _compute_score_deriv(self, psi_elements, coef):
         return psi_elements['psi_a']
 
-    def _est_coef(self, psi_elements, dml_procedure, smpls):
-
-        if dml_procedure == 'dml1':
-            # Note that len(smpls) is only not equal to self.n_folds if self.apply_cross_fitting = False
-            dml1_coefs = np.zeros(len(smpls))
-            for idx, (_, test_index) in enumerate(smpls):
-                psi_a = psi_elements['psi_a'][test_index]
-                psi_b = psi_elements['psi_b'][test_index]
-
-                scaling_factor = 1./len(psi_a)
-                dml1_coefs[idx] = - (scaling_factor * np.sum(psi_b)) / (scaling_factor * np.sum(psi_a))
-            coef = np.mean(dml1_coefs)
-        else:
-            assert dml_procedure == 'dml2'
-            dml1_coefs = None
-            psi_a = psi_elements['psi_a']
-            psi_b = psi_elements['psi_b']
-
-            scaling_factor = 1./len(psi_a)
-            coef = - (scaling_factor * np.sum(psi_b)) / (scaling_factor * np.sum(psi_a))
-        return coef, dml1_coefs
+    def _est_coef(self, psi_elements, inds=None):
+        psi_a = psi_elements['psi_a']
+        psi_b = psi_elements['psi_b']
+        if inds is not None:
+            psi_a = psi_a[inds]
+            psi_b = psi_b[inds]
+        
+        scaling_factor = 1./len(psi_a)
+        coef = - (scaling_factor * np.sum(psi_b)) / (scaling_factor * np.sum(psi_a))
+        return coef
 
     def _est_coef_cluster_data(self, psi_elements, dml_procedure, smpls, smpls_cluster):
         psi_a = psi_elements['psi_a']

--- a/doubleml/double_ml_score_mixins.py
+++ b/doubleml/double_ml_score_mixins.py
@@ -45,9 +45,9 @@ class LinearScoreMixin:
         if inds is not None:
             psi_a = psi_a[inds]
             psi_b = psi_b[inds]
-
-        coef = -np.mean(psi_b) / np.mean(psi_a)
-
+        
+        scaling_factor = 1./len(psi_a)
+        coef = - (scaling_factor * np.sum(psi_b)) / (scaling_factor * np.sum(psi_a))
         return coef
 
     def _est_coef_cluster_data(self, psi_elements, dml_procedure, smpls, smpls_cluster):

--- a/doubleml/double_ml_score_mixins.py
+++ b/doubleml/double_ml_score_mixins.py
@@ -39,16 +39,27 @@ class LinearScoreMixin:
     def _compute_score_deriv(self, psi_elements, coef):
         return psi_elements['psi_a']
 
-    def _est_coef(self, psi_elements, inds=None):
-        psi_a = psi_elements['psi_a']
-        psi_b = psi_elements['psi_b']
-        if inds is not None:
-            psi_a = psi_a[inds]
-            psi_b = psi_b[inds]
-        
-        scaling_factor = 1./len(psi_a)
-        coef = - (scaling_factor * np.sum(psi_b)) / (scaling_factor * np.sum(psi_a))
-        return coef
+    def _est_coef(self, psi_elements, dml_procedure, smpls):
+
+        if dml_procedure == 'dml1':
+            # Note that len(smpls) is only not equal to self.n_folds if self.apply_cross_fitting = False
+            dml1_coefs = np.zeros(len(smpls))
+            for idx, (_, test_index) in enumerate(smpls):
+                psi_a = psi_elements['psi_a'][test_index]
+                psi_b = psi_elements['psi_b'][test_index]
+
+                scaling_factor = 1./len(psi_a)
+                dml1_coefs[idx] = - (scaling_factor * np.sum(psi_b)) / (scaling_factor * np.sum(psi_a))
+            coef = np.mean(dml1_coefs)
+        else:
+            assert dml_procedure == 'dml2'
+            dml1_coefs = None
+            psi_a = psi_elements['psi_a']
+            psi_b = psi_elements['psi_b']
+
+            scaling_factor = 1./len(psi_a)
+            coef = - (scaling_factor * np.sum(psi_b)) / (scaling_factor * np.sum(psi_a))
+        return coef, dml1_coefs
 
     def _est_coef_cluster_data(self, psi_elements, dml_procedure, smpls, smpls_cluster):
         psi_a = psi_elements['psi_a']

--- a/doubleml/double_ml_score_mixins.py
+++ b/doubleml/double_ml_score_mixins.py
@@ -48,15 +48,13 @@ class LinearScoreMixin:
 
         # check whether we have cluster data and dml2
         is_dml2_and_cluster = self._is_cluster_data and (self.dml_procedure == 'dml2')
+        if not is_dml2_and_cluster:
+            coef = - np.mean(psi_b) / np.mean(psi_a)
         # for cluster and dml2 we need the smpls and the scaling factors
-        if is_dml2_and_cluster:
+        else:
             assert smpls is not None
             assert scaling_factor is not None
             assert inds is None
-
-        if not is_dml2_and_cluster:
-            coef = - np.mean(psi_b) / np.mean(psi_a)
-        else:
             # if we have clustered data and dml2 the solution is the root of a weighted sum
             psi_a_subsample_mean = 0.
             psi_b_subsample_mean = 0.
@@ -112,7 +110,7 @@ class NonLinearScoreMixin:
 
         # check whether we have cluster data and dml2
         is_dml2_and_cluster = self._is_cluster_data and (self.dml_procedure == 'dml2')
-        # for cluster and dml2 we need the smpls and the scaling factors
+        # for cluster and dml2 we need the smpls and the scaling factors (only check once)
         if is_dml2_and_cluster:
             assert smpls is not None
             assert scaling_factor is not None

--- a/doubleml/tests/test_nonlinear_cluster.py
+++ b/doubleml/tests/test_nonlinear_cluster.py
@@ -1,0 +1,248 @@
+import numpy as np
+import pytest
+import math
+
+from sklearn.base import clone
+from sklearn.linear_model import LinearRegression, Lasso
+from sklearn.ensemble import RandomForestRegressor
+
+import doubleml as dml
+from doubleml.datasets import make_pliv_multiway_cluster_CKMS2021, DoubleMLClusterData
+
+from .test_nonlinear_score_mixin import DoubleMLPLRWithNonLinearScoreMixin
+
+np.random.seed(1234)
+# Set the simulation parameters
+N = 25  # number of observations (first dimension)
+M = 25  # number of observations (second dimension)
+dim_x = 100  # dimension of x
+
+# create data without insturment for plr
+x, y, d, cluster_vars, z = make_pliv_multiway_cluster_CKMS2021(N, M, dim_x, return_type="array")
+obj_dml_cluster_data = DoubleMLClusterData.from_arrays(x, y, d, cluster_vars)
+
+x, y, d, cluster_vars, z = make_pliv_multiway_cluster_CKMS2021(N, M, dim_x,
+                                                               omega_X=np.array([0.25, 0]),
+                                                               omega_epsilon=np.array([0.25, 0]),
+                                                               omega_v=np.array([0.25, 0]),
+                                                               omega_V=np.array([0.25, 0]),
+                                                               return_type='array')
+obj_dml_oneway_cluster_data = DoubleMLClusterData.from_arrays(x, y, d, cluster_vars)
+
+# only the first cluster variable is relevant with the weight setting above
+obj_dml_oneway_cluster_data.cluster_cols = 'cluster_var1'
+
+
+@pytest.fixture(scope='module',
+                params=[RandomForestRegressor(max_depth=2, n_estimators=10),
+                        LinearRegression(),
+                        Lasso(alpha=0.1)])
+def learner(request):
+    return request.param
+
+
+@pytest.fixture(scope='module',
+                params=['IV-type', 'partialling out'])
+def score(request):
+    return request.param
+
+
+@pytest.fixture(scope='module',
+                params=['dml1', 'dml2'])
+def dml_procedure(request):
+    return request.param
+
+
+@pytest.fixture(scope='module')
+def dml_plr_oneway_cluster_linear_vs_nonlinear_fixture(learner, score, dml_procedure):
+    n_folds = 3
+
+    # Set machine learning methods for l, m & g
+    ml_l = clone(learner)
+    ml_m = clone(learner)
+    ml_g = clone(learner)
+
+    np.random.seed(3141)
+    if score == 'partialling out':
+        dml_plr_obj = dml.DoubleMLPLR(obj_dml_oneway_cluster_data,
+                                      ml_l, ml_m,
+                                      n_folds=n_folds,
+                                      score=score,
+                                      dml_procedure=dml_procedure)
+    else:
+        assert score == 'IV-type'
+        dml_plr_obj = dml.DoubleMLPLR(obj_dml_oneway_cluster_data,
+                                      ml_l, ml_m, ml_g,
+                                      n_folds=n_folds,
+                                      score=score,
+                                      dml_procedure=dml_procedure)
+
+    np.random.seed(3141)
+    dml_plr_obj.fit()
+
+    np.random.seed(3141)
+    if score == 'partialling out':
+        dml_plr_obj2 = DoubleMLPLRWithNonLinearScoreMixin(obj_dml_oneway_cluster_data,
+                                                          ml_l, ml_m,
+                                                          n_folds=n_folds,
+                                                          score=score,
+                                                          dml_procedure=dml_procedure)
+    else:
+        assert score == 'IV-type'
+        dml_plr_obj2 = DoubleMLPLRWithNonLinearScoreMixin(obj_dml_oneway_cluster_data,
+                                                          ml_l, ml_m, ml_g,
+                                                          n_folds=n_folds,
+                                                          score=score,
+                                                          dml_procedure=dml_procedure)
+
+    np.random.seed(3141)
+    dml_plr_obj2.fit()
+
+    res_dict = {'coef_linear': dml_plr_obj.coef,
+                'coef_nonlinear': dml_plr_obj2.coef,
+                'se_linear': dml_plr_obj.se,
+                'se_nonlinear': dml_plr_obj2.se}
+
+    return res_dict
+
+
+@pytest.mark.ci
+def test_dml_plr_oneway_cluster_linear_vs_nonlinear_coef(dml_plr_oneway_cluster_linear_vs_nonlinear_fixture):
+    assert math.isclose(dml_plr_oneway_cluster_linear_vs_nonlinear_fixture['coef_linear'],
+                        dml_plr_oneway_cluster_linear_vs_nonlinear_fixture['coef_nonlinear'],
+                        rel_tol=1e-9, abs_tol=1e-4)
+
+
+@pytest.mark.ci
+def test_dml_plr_oneway_cluster_linear_vs_nonlinear_se(dml_plr_oneway_cluster_linear_vs_nonlinear_fixture):
+    assert math.isclose(dml_plr_oneway_cluster_linear_vs_nonlinear_fixture['se_linear'],
+                        dml_plr_oneway_cluster_linear_vs_nonlinear_fixture['se_nonlinear'],
+                        rel_tol=1e-9, abs_tol=1e-4)
+
+
+@pytest.fixture(scope='module')
+def dml_plr_multiway_cluster_linear_vs_nonlinear_fixture(learner, score, dml_procedure):
+    n_folds = 2
+    n_rep = 2
+
+    # Set machine learning methods for l, m & g
+    ml_l = clone(learner)
+    ml_m = clone(learner)
+    ml_g = clone(learner)
+
+    np.random.seed(3141)
+    if score == 'partialling out':
+        dml_plr_obj = dml.DoubleMLPLR(obj_dml_oneway_cluster_data,
+                                      ml_l, ml_m,
+                                      n_folds=n_folds,
+                                      n_rep=n_rep,
+                                      score=score,
+                                      dml_procedure=dml_procedure)
+    else:
+        assert score == 'IV-type'
+        dml_plr_obj = dml.DoubleMLPLR(obj_dml_oneway_cluster_data,
+                                      ml_l, ml_m, ml_g,
+                                      n_folds=n_folds,
+                                      n_rep=n_rep,
+                                      score=score,
+                                      dml_procedure=dml_procedure)
+
+    np.random.seed(3141)
+    dml_plr_obj.fit()
+
+    np.random.seed(3141)
+    if score == 'partialling out':
+        dml_plr_obj2 = DoubleMLPLRWithNonLinearScoreMixin(obj_dml_oneway_cluster_data,
+                                                          ml_l, ml_m,
+                                                          n_folds=n_folds,
+                                                          n_rep=n_rep,
+                                                          score=score,
+                                                          dml_procedure=dml_procedure)
+    else:
+        assert score == 'IV-type'
+        dml_plr_obj2 = DoubleMLPLRWithNonLinearScoreMixin(obj_dml_oneway_cluster_data,
+                                                          ml_l, ml_m, ml_g,
+                                                          n_folds=n_folds,
+                                                          n_rep=n_rep,
+                                                          score=score,
+                                                          dml_procedure=dml_procedure)
+
+    np.random.seed(3141)
+    dml_plr_obj2.fit()
+
+    res_dict = {'coef_linear': dml_plr_obj.coef,
+                'coef_nonlinear': dml_plr_obj2.coef,
+                'se_linear': dml_plr_obj.se,
+                'se_nonlinear': dml_plr_obj2.se}
+
+    return res_dict
+
+
+@pytest.mark.ci
+def test_dml_plr_multiway_cluster_linear_vs_nonlinear_coef(dml_plr_multiway_cluster_linear_vs_nonlinear_fixture):
+    assert math.isclose(dml_plr_multiway_cluster_linear_vs_nonlinear_fixture['coef_linear'],
+                        dml_plr_multiway_cluster_linear_vs_nonlinear_fixture['coef_nonlinear'],
+                        rel_tol=1e-9, abs_tol=1e-4)
+
+
+@pytest.mark.ci
+def test_dml_plr_multiway_cluster_linear_vs_nonlinear_se(dml_plr_multiway_cluster_linear_vs_nonlinear_fixture):
+    assert math.isclose(dml_plr_multiway_cluster_linear_vs_nonlinear_fixture['se_linear'],
+                        dml_plr_multiway_cluster_linear_vs_nonlinear_fixture['se_nonlinear'],
+                        rel_tol=1e-9, abs_tol=1e-4)
+
+
+@pytest.fixture(scope="module")
+def dml_plr_cluster_nonlinear_with_index(generate_data1, learner, dml_procedure):
+    # in the one-way cluster case with exactly one observation per cluster, we get the same result w & w/o clustering
+    n_folds = 2
+
+    # collect data
+    data = generate_data1
+    x_cols = data.columns[data.columns.str.startswith('X')].tolist()
+
+    # Set machine learning methods for m & l
+    ml_l = clone(learner)
+    ml_m = clone(learner)
+
+    obj_dml_data = dml.DoubleMLData(data, 'y', ['d'], x_cols)
+    np.random.seed(3141)
+    dml_plr_obj = DoubleMLPLRWithNonLinearScoreMixin(obj_dml_data,
+                                                     ml_l, ml_m,
+                                                     n_folds=n_folds,
+                                                     dml_procedure=dml_procedure)
+    dml_plr_obj.fit()
+
+    df = data.reset_index()
+    dml_cluster_data = dml.DoubleMLClusterData(df,
+                                               y_col='y',
+                                               d_cols='d',
+                                               x_cols=x_cols,
+                                               cluster_cols='index')
+    np.random.seed(3141)
+    dml_plr_cluster_obj = DoubleMLPLRWithNonLinearScoreMixin(dml_cluster_data,
+                                                             ml_l, ml_m,
+                                                             n_folds=n_folds,
+                                                             dml_procedure=dml_procedure)
+    dml_plr_cluster_obj.fit()
+
+    res_dict = {'coef': dml_plr_obj.coef,
+                'coef_cluster': dml_plr_cluster_obj.coef,
+                'se': dml_plr_obj.se,
+                'se_cluster': dml_plr_cluster_obj.se}
+
+    return res_dict
+
+
+@pytest.mark.ci
+def test_dml_plr_cluster_nonlinear_with_index_coef(dml_plr_cluster_nonlinear_with_index):
+    assert math.isclose(dml_plr_cluster_nonlinear_with_index['coef'],
+                        dml_plr_cluster_nonlinear_with_index['coef_cluster'],
+                        rel_tol=1e-9, abs_tol=1e-4)
+
+
+@pytest.mark.ci
+def test_dml_plr_cluster_nonlinear_with_index_se(dml_plr_cluster_nonlinear_with_index):
+    assert math.isclose(dml_plr_cluster_nonlinear_with_index['se'],
+                        dml_plr_cluster_nonlinear_with_index['se_cluster'],
+                        rel_tol=1e-9, abs_tol=1e-4)

--- a/doubleml/tests/test_nonlinear_score_mixin.py
+++ b/doubleml/tests/test_nonlinear_score_mixin.py
@@ -8,7 +8,6 @@ from sklearn.utils import check_X_y
 
 import doubleml as dml
 from doubleml.double_ml import DoubleML
-from doubleml.datasets import make_pliv_multiway_cluster_CKMS2021
 from doubleml._utils import _dml_cv_predict, _check_finite_predictions
 from doubleml.double_ml_score_mixins import NonLinearScoreMixin
 
@@ -286,16 +285,3 @@ def test_nonlinear_warnings(generate_data1, coef_bounds):
     with pytest.warns(UserWarning, match=msg):
         dml_plr_obj._coef_bounds = coef_bounds
         dml_plr_obj.fit()
-
-
-@pytest.mark.ci
-def test_doubleml_cluster_not_implemented_exception():
-    np.random.seed(3141)
-    dml_data = make_pliv_multiway_cluster_CKMS2021()
-    dml_data.z_cols = None
-    ml_l = LinearRegression()
-    ml_m = LinearRegression()
-    dml_plr = DoubleMLPLRWithNonLinearScoreMixin(dml_data, ml_l, ml_m)
-    msg = 'Estimation with clustering not implemented.'
-    with pytest.raises(NotImplementedError, match=msg):
-        _ = dml_plr.fit()


### PR DESCRIPTION
Refactoring of the `_est_coef` method in both mixin classes to allow for a scaling factor which enables cluster robust estimation and standard errors.
The method `_est_causal_pars` form the `DoubleML` class now calculates a `scaling_factor` if clustering is used. 
If the scaling factor is not `None`, the estimation in `_est_coef` is done with scaling (for both linear and nonlinear mixins).

### Reference to Issues or PRs
#189 


### PR Checklist

- [x] The title of the pull request summarizes the changes made.
- [x] The PR contains a detailed description of all changes and additions.
- [x] References to related issues or PRs are added.
- [x] The code passes all (unit) tests.
- [x] Enhancements or new feature are equipped with unit tests.
- [x] The changes adhere to the PEP8 standards.
