### PR TITLE
Add Policy Tree class for learning policies based on IRM 

### DIFF
--- a/doubleml/__init__.py
+++ b/doubleml/__init__.py
@@ -12,6 +12,7 @@ from .double_ml_qte import DoubleMLQTE
 from .double_ml_pq import DoubleMLPQ
 from .double_ml_lpq import DoubleMLLPQ
 from .double_ml_cvar import DoubleMLCVAR
+from .double_ml_policytree import DoubleMLPolicyTree
 
 __all__ = ['DoubleMLPLR',
            'DoubleMLPLIV',
@@ -25,6 +26,7 @@ __all__ = ['DoubleMLPLR',
            'DoubleMLPQ',
            'DoubleMLQTE',
            'DoubleMLLPQ',
-           'DoubleMLCVAR']
+           'DoubleMLCVAR',
+           'DoubleMLPolicyTree']
 
 __version__ = get_distribution('doubleml').version

--- a/doubleml/double_ml_irm.py
+++ b/doubleml/double_ml_irm.py
@@ -472,3 +472,42 @@ class DoubleMLIRM(LinearScoreMixin, DoubleML):
         model = DoubleMLBLP(orth_signal, basis=groups, is_gate=True).fit()
 
         return model
+    
+    def policy_tree(self, x_vars, depth):
+        """
+        Estimate a decision tree for optimal treatment policy.
+
+        Parameters
+        ----------
+        depth : int
+            The depth of the estimated decision tree.
+            Has to be larger than 0. Deeper trees derive a more complex decision policy.
+            However, they tend to overfit more.
+
+        groups : :class:`pandas.DataFrame`
+            The covariates on which the policy tree is learnt.
+            Has to be of shape ``(n_obs, d)``, where ``n_obs`` is the number of observations
+            and ``d`` is the number of covariates to be included.
+
+        Returns
+        -------
+        model : :class:`doubleML.DoubleMLPolicyTree`
+            Policy tree model.
+        """
+        if not isinstance(depth, int):
+            raise TypeError('Tree depth must be of int type. '
+                            f'Depth of type {str(type(depth))} was passed.')
+        
+        if not (depth>0):
+            raise ValueError('Tree depth must be greater than 0. '
+                             f'Depth {depth} was passed.')
+        
+        if not isinstance(x_vars, pd.DataFrame):
+            raise TypeError('Groups must be of DataFrame type. '
+                            f'Groups of type {str(type(x_vars))} was passed.')
+        
+        orth_signal = self.psi_elements['psi_b'].reshape(-1)
+        
+        model = DoubleMLPolicyTree(orth_signal, depth=depth, x_vars=x_vars).fit()
+
+        return model

--- a/doubleml/double_ml_irm.py
+++ b/doubleml/double_ml_irm.py
@@ -474,21 +474,26 @@ class DoubleMLIRM(LinearScoreMixin, DoubleML):
 
         return model
     
-    def policy_tree(self, x_vars, depth):
+    def policy_tree(self, x_vars, depth=2, **tree_params):
         """
-        Estimate a decision tree for optimal treatment policy.
+        Estimate a decision tree for optimal treatment policy by weighted classification.
 
         Parameters
         ----------
         depth : int
             The depth of the estimated decision tree.
             Has to be larger than 0. Deeper trees derive a more complex decision policy.
-            However, they tend to overfit more.
+            However, they tend to overfit more. Default is 2.
 
         groups : :class:`pandas.DataFrame`
             The covariates on which the policy tree is learnt.
             Has to be of shape ``(n_obs, d)``, where ``n_obs`` is the number of observations
             and ``d`` is the number of covariates to be included.
+
+        **tree_params : dict
+            Parameters that are forwarded to the :class:`sklearn.tree.DecisionTreeClassifier`.
+            Note that by default we perform minimal pruning by setting the ``ccp_alpha = 0.01`` and
+            ``min_samples_leaf = 5``. This can be adjusted.
 
         Returns
         -------
@@ -512,6 +517,6 @@ class DoubleMLIRM(LinearScoreMixin, DoubleML):
         
         orth_signal = self.psi_elements['psi_b'].reshape(-1)
         
-        model = DoubleMLPolicyTree(orth_signal, depth=depth, x_vars=x_vars).fit()
+        model = DoubleMLPolicyTree(orth_signal, depth=depth, x_vars=x_vars, **tree_params).fit()
 
         return model

--- a/doubleml/double_ml_irm.py
+++ b/doubleml/double_ml_irm.py
@@ -7,11 +7,12 @@ from sklearn.utils.multiclass import type_of_target
 from .double_ml import DoubleML
 
 from .double_ml_blp import DoubleMLBLP
+from .double_ml_policytree import DoubleMLPolicyTree
 from .double_ml_data import DoubleMLData
 from .double_ml_score_mixins import LinearScoreMixin
 
 from ._utils import _dml_cv_predict, _get_cond_smpls, _dml_tune, _trimm, _normalize_ipw
-from ._utils_checks import _check_score, _check_trimming, _check_finite_predictions, _check_is_propensity
+from ._utils_checks import _check_score, _check_trimming, _check_finite_predictions, _check_is_propensity, _check_integer
 
 
 class DoubleMLIRM(LinearScoreMixin, DoubleML):
@@ -494,13 +495,7 @@ class DoubleMLIRM(LinearScoreMixin, DoubleML):
         model : :class:`doubleML.DoubleMLPolicyTree`
             Policy tree model.
         """
-        if not isinstance(depth, int):
-            raise TypeError('Tree depth must be of int type. '
-                            f'Depth of type {str(type(depth))} was passed.')
-        
-        if not (depth>0):
-            raise ValueError('Tree depth must be greater than 0. '
-                             f'Depth {depth} was passed.')
+        _check_integer(depth, "Depth", 0)        
         
         if not isinstance(x_vars, pd.DataFrame):
             raise TypeError('Groups must be of DataFrame type. '

--- a/doubleml/double_ml_irm.py
+++ b/doubleml/double_ml_irm.py
@@ -495,11 +495,20 @@ class DoubleMLIRM(LinearScoreMixin, DoubleML):
         model : :class:`doubleML.DoubleMLPolicyTree`
             Policy tree model.
         """
+        valid_score = ['ATE']
+        if self.score not in valid_score:
+            raise ValueError('Invalid score ' + self.score + '. ' +
+                             'Valid score ' + ' or '.join(valid_score) + '.')
+
+        if self.n_rep != 1:
+            raise NotImplementedError('Only implemented for one repetition. ' +
+                                      f'Number of repetitions is {str(self.n_rep)}.')
+        
         _check_integer(depth, "Depth", 0)        
         
         if not isinstance(x_vars, pd.DataFrame):
-            raise TypeError('Groups must be of DataFrame type. '
-                            f'Groups of type {str(type(x_vars))} was passed.')
+            raise TypeError('Covariates must be of DataFrame type. '
+                            f'Covariates of type {str(type(x_vars))} was passed.')
         
         orth_signal = self.psi_elements['psi_b'].reshape(-1)
         

--- a/doubleml/double_ml_policytree.py
+++ b/doubleml/double_ml_policytree.py
@@ -74,30 +74,19 @@ class DoubleMLPolicyTree:
         return self._orth_signal
 
     @property
-    def basis(self):
+    def x_vars(self):
         """
-        Basis.
+        Covariates.
         """
-        return self._basis
+        return self._x_vars
 
     @property
     def summary(self):
         """
-        A summary for the best linear predictor effect after calling :meth:`fit`.
+        A summary for the policy tree after calling :meth:`fit`.
         """
-        col_names = ['coef', 'std err', 't', 'P>|t|', '[0.025', '0.975]']
-        if self.blp_model is None:
-            df_summary = pd.DataFrame(columns=col_names)
-        else:
-            summary_stats = {'coef': self.blp_model.params,
-                             'std err': self.blp_model.bse,
-                             't': self.blp_model.tvalues,
-                             'P>|t|': self.blp_model.pvalues,
-                             '[0.025': self.blp_model.conf_int()[0],
-                             '0.975]': self.blp_model.conf_int()[1]}
-            df_summary = pd.DataFrame(summary_stats,
-                                      columns=col_names)
-        return df_summary
+        # TODO: Write summary function
+        return 
 
     def fit(self):
         """
@@ -118,5 +107,24 @@ class DoubleMLPolicyTree:
         return self
 
     def plot_tree(self):
+        """
+        Plots the DoubleMLPolicyTree.
+
+        Returns
+        -------
+        self : object
+        """
         # TODO: Implement plotting for fitted tree
-        return None
+        return
+    
+    def predict(self, x):
+        """
+        Predicts policy based on the DoubleMLPolicyTree.
+
+        Returns
+        -------
+        self : object
+        """
+        # TODO: Implement predict method for fitted tree
+        return
+

--- a/doubleml/double_ml_policytree.py
+++ b/doubleml/double_ml_policytree.py
@@ -1,0 +1,122 @@
+import numpy as np
+import pandas as pd
+
+from sklearn.tree import DecisionTreeClassifier
+
+
+class DoubleMLPolicyTree:
+    """Policy Tree fitting for DoubleML.
+    Currently avaivable for IRM models.
+
+    Parameters
+    ----------
+    orth_signal : :class:`numpy.array`
+        The orthogonal signal to be predicted. Has to be of shape ``(n_obs,)``,
+        where ``n_obs`` is the number of observations.
+
+    x_vars : :class:`pandas.DataFrame`
+        The covariates for estimating the policy tree. Has to have the shape ``(n_obs, d)``,
+        where ``n_obs`` is the number of observations and ``d`` is the number of predictors.
+
+    depth : bool
+        Indicates whether the basis is constructed for GATEs (dummy-basis).
+        Default is ``False``.
+    """
+
+    def __init__(self,
+                 orth_signal,
+                 x_vars,
+                 depth):
+
+        if not isinstance(orth_signal, np.ndarray):
+            raise TypeError('The signal must be of np.ndarray type. '
+                            f'Signal of type {str(type(orth_signal))} was passed.')
+
+        if orth_signal.ndim != 1:
+            raise ValueError('The signal must be of one dimensional. '
+                             f'Signal of dimensions {str(orth_signal.ndim)} was passed.')
+
+        if not isinstance(x_vars, pd.DataFrame):
+            raise TypeError('The basis must be of DataFrame type. '
+                            f'Basis of type {str(type(x_vars))} was passed.')
+
+        if not x_vars.columns.is_unique:
+            raise ValueError('Invalid pd.DataFrame: '
+                             'Contains duplicate column names.')
+
+        self._orth_signal = orth_signal
+        self._x_vars = x_vars
+        self._depth = depth
+
+        # initialize tree
+        self._policy_tree = DecisionTreeClassifier(max_depth = depth)
+
+    def __str__(self):
+        class_name = self.__class__.__name__
+        header = f'================== {class_name} Object ==================\n'
+        fit_summary = str(self.summary)
+        res = header + \
+            '\n------------------ Fit summary ------------------\n' + fit_summary
+        return res
+
+    @property
+    def policy_tree(self):
+        """
+        Policy tree model.
+        """
+        return self._policy_tree
+
+    @property
+    def orth_signal(self):
+        """
+        Orthogonal signal.
+        """
+        return self._orth_signal
+
+    @property
+    def basis(self):
+        """
+        Basis.
+        """
+        return self._basis
+
+    @property
+    def summary(self):
+        """
+        A summary for the best linear predictor effect after calling :meth:`fit`.
+        """
+        col_names = ['coef', 'std err', 't', 'P>|t|', '[0.025', '0.975]']
+        if self.blp_model is None:
+            df_summary = pd.DataFrame(columns=col_names)
+        else:
+            summary_stats = {'coef': self.blp_model.params,
+                             'std err': self.blp_model.bse,
+                             't': self.blp_model.tvalues,
+                             'P>|t|': self.blp_model.pvalues,
+                             '[0.025': self.blp_model.conf_int()[0],
+                             '0.975]': self.blp_model.conf_int()[1]}
+            df_summary = pd.DataFrame(summary_stats,
+                                      columns=col_names)
+        return df_summary
+
+    def fit(self):
+        """
+        Estimate DoubleMLPolicyTree models.
+
+        Returns
+        -------
+        self : object
+        """
+        bin_signal = (np.sign(self._orth_signal) + 1) / 2
+        abs_signal = np.abs(self._orth_signal)
+
+        # fit the tree with target binary score, sample weights absolute score and 
+        # provided feature variables
+        self._blp_model = self._policy_tree.fit(X=self._x_vars, y=bin_signal, 
+                                                sample_weight=abs_signal)
+
+        return self
+
+    def plot_tree(self):
+        # TODO: Implement plotting for fitted tree
+        return None

--- a/doubleml/tests/_utils_pt_manual.py
+++ b/doubleml/tests/_utils_pt_manual.py
@@ -1,0 +1,13 @@
+import numpy as np
+from sklearn.tree import DecisionTreeClassifier
+import pandas as pd
+
+
+def fit_policytree(orth_signal, x_vars, depth):
+    policytree_model = DecisionTreeClassifier(max_depth=depth, 
+                                              ccp_alpha=.01, 
+                                              min_samples_leaf=5).fit(X=x_vars, 
+                                                                      y=(np.sign(orth_signal) + 1) / 2,
+                                                                      sample_weight=np.abs(orth_signal))
+
+    return policytree_model

--- a/doubleml/tests/test_doubleml_exceptions.py
+++ b/doubleml/tests/test_doubleml_exceptions.py
@@ -1329,7 +1329,7 @@ def test_doubleml_exception_policytree():
     with pytest.raises(ValueError, match=msg):
         dml_irm_obj.policy_tree(x_vars=pd.DataFrame(np.random.normal(0, 1, size=(dml_data_irm.n_obs, 3))),
                                 depth=-1)
-    msg = "Depth must be an integer. 0.1 of type  was passed."
+    msg = "Depth must be an integer. 0.1 of type <class 'float'> was passed."
     with pytest.raises(TypeError, match=msg):
         dml_irm_obj.policy_tree(x_vars=pd.DataFrame(np.random.normal(0, 1, size=(dml_data_irm.n_obs, 3))),
                                 depth=.1)

--- a/doubleml/tests/test_doubleml_exceptions.py
+++ b/doubleml/tests/test_doubleml_exceptions.py
@@ -1312,3 +1312,48 @@ def test_double_ml_exception_evaluate_learner():
         return np.nan
     with pytest.raises(ValueError, match=msg):
         dml_irm_obj.evaluate_learners(metric=eval_fct)
+
+@pytest.mark.ci
+def test_doubleml_exception_policytree():
+    dml_irm_obj = DoubleMLIRM(dml_data_irm,
+                              ml_g=Lasso(),
+                              ml_m=LogisticRegression(),
+                              trimming_threshold=0.05,
+                              n_folds=5)
+    dml_irm_obj.fit()
+
+    msg = "Covariates must be of DataFrame type. Covariates of type <class 'int'> was passed."
+    with pytest.raises(TypeError, match=msg):
+        dml_irm_obj.policy_tree(x_vars=2, depth = 1)
+    msg = "Depth must be larger or equal to 0. -1 was passed."
+    with pytest.raises(ValueError, match=msg):
+        dml_irm_obj.policy_tree(x_vars=pd.DataFrame(np.random.normal(0, 1, size=(dml_data_irm.n_obs, 3))),
+                                depth=-1)
+    msg = "Depth must be an integer. 0.1 of type  was passed."
+    with pytest.raises(TypeError, match=msg):
+        dml_irm_obj.policy_tree(x_vars=pd.DataFrame(np.random.normal(0, 1, size=(dml_data_irm.n_obs, 3))),
+                                depth=.1)
+
+    dml_irm_obj = DoubleMLIRM(dml_data_irm,
+                              ml_g=Lasso(),
+                              ml_m=LogisticRegression(),
+                              trimming_threshold=0.05,
+                              n_folds=5,
+                              score='ATTE')
+    dml_irm_obj.fit()
+
+    msg = 'Invalid score ATTE. Valid score ATE.'
+    with pytest.raises(ValueError, match=msg):
+        dml_irm_obj.policy_tree(x_vars=2, depth=1)
+
+    dml_irm_obj = DoubleMLIRM(dml_data_irm,
+                              ml_g=Lasso(),
+                              ml_m=LogisticRegression(),
+                              trimming_threshold=0.05,
+                              n_folds=5,
+                              score='ATE',
+                              n_rep=2)
+    dml_irm_obj.fit()
+    msg = 'Only implemented for one repetition. Number of repetitions is 2.'
+    with pytest.raises(NotImplementedError, match=msg):
+        dml_irm_obj.policy_tree(x_vars=2, depth=1)

--- a/doubleml/tests/test_doubleml_model_defaults.py
+++ b/doubleml/tests/test_doubleml_model_defaults.py
@@ -54,6 +54,8 @@ dml_pq.bootstrap()
 dml_lpq.bootstrap()
 dml_qte.bootstrap()
 
+policy_tree = dml_irm.policy_tree(x_vars=dml_data_irm.data.drop(columns=["y","d"]))
+
 
 def _assert_resampling_default_settings(dml_obj):
     assert dml_obj.n_folds == 5
@@ -188,3 +190,10 @@ def test_sensitivity_defaults():
 
     dml_plr.sensitivity_analysis()
     assert dml_plr._sensitivity_params['input'] == input_dict
+
+
+@pytest.mark.ci
+def test_policytree_defaults():
+    assert policy_tree.policy_tree.max_depth == 2
+    assert policy_tree.policy_tree.min_samples_leaf == 5
+    assert policy_tree.policy_tree.ccp_alpha == 0.01

--- a/doubleml/tests/test_irm.py
+++ b/doubleml/tests/test_irm.py
@@ -209,3 +209,30 @@ def test_dml_irm_cate_gate():
     assert isinstance(gate_2, dml.double_ml_blp.DoubleMLBLP)
     assert isinstance(gate_2.confint(), pd.DataFrame)
     assert all(gate_2.confint().index == ["Group_1", "Group_2"])
+
+@pytest.mark.ci
+def test_dml_irm_policytree():
+    n = 11
+    p = 2
+    # collect data
+    np.random.seed(42)
+    obj_dml_data = make_irm_data(n_obs=n, dim_x=p)
+
+    # First stage estimation
+    ml_g = RandomForestRegressor(n_estimators=10)
+    ml_m = RandomForestClassifier(n_estimators=10)
+
+    dml_irm_obj = dml.DoubleMLIRM(obj_dml_data,
+                                    ml_m=ml_m,
+                                    ml_g=ml_g,
+                                    trimming_threshold=0.05,
+                                    n_folds=5)
+
+    dml_irm_obj.fit()
+    # create a covariate basis
+    x_vars = obj_dml_data.data.drop(columns=["y","d"])
+    policy_tree = dml_irm_obj.policy_tree(x_vars, depth=1)
+    assert isinstance(policy_tree, dml.double_ml_policytree.DoubleMLPolicyTree)
+    assert isinstance(policy_tree.plot_tree(), list)
+    predict_x_vars = pd.DataFrame(np.random.normal(size=(5,2)), columns=x_vars.keys())
+    assert isinstance(policy_tree.predict(predict_x_vars), pd.DataFrame)

--- a/doubleml/tests/test_policytree.py
+++ b/doubleml/tests/test_policytree.py
@@ -1,0 +1,107 @@
+import numpy as np
+import pandas as pd
+import pytest
+import copy
+
+import doubleml as dml
+
+from ._utils_pt_manual import fit_policytree
+from sklearn.tree import DecisionTreeClassifier
+from sklearn.exceptions import NotFittedError
+
+
+@pytest.fixture(scope='module',
+                params=[1,2,3])
+def depth(request):
+    return request.param
+
+
+@pytest.fixture(scope='module')
+def dml_policytree_fixture(depth):
+    n = 50
+    np.random.seed(42)
+    random_x_var = pd.DataFrame(np.random.normal(0, 1, size=(n, 3)))
+    random_signal = np.random.normal(0, 1, size=(n, ))
+
+    policy_tree = dml.DoubleMLPolicyTree(random_signal, random_x_var, depth)
+
+    policy_tree_obj = copy.copy(policy_tree)
+    np.random.seed(42)
+    policy_tree.fit()
+    np.random.seed(42)
+    policy_tree_manual = fit_policytree(random_signal, random_x_var, depth)
+
+    res_dict = {'tree': policy_tree.policy_tree.tree_,
+                'tree_manual': policy_tree_manual.tree_,
+                'x_vars': policy_tree.x_vars,
+                'signal': policy_tree.orth_signal,
+                'policytree_model': policy_tree,
+                'unfitted_policytree_model': policy_tree_obj}
+
+    return res_dict
+
+
+@pytest.mark.ci
+def test_dml_policytree_treshold(dml_policytree_fixture):
+    assert np.allclose(dml_policytree_fixture['tree'].threshold,
+                       dml_policytree_fixture['tree_manual'].threshold,
+                       rtol=1e-9, atol=1e-4)
+
+
+@pytest.mark.ci
+def test_dml_policytree_children(dml_policytree_fixture):
+    assert np.allclose(dml_policytree_fixture['tree'].children_left,
+                       dml_policytree_fixture['tree_manual'].children_left,
+                       rtol=1e-9, atol=1e-4)
+
+
+@pytest.mark.ci
+def test_dml_policytree_children(dml_policytree_fixture):
+    assert np.allclose(dml_policytree_fixture['tree'].children_right,
+                       dml_policytree_fixture['tree_manual'].children_right,
+                       rtol=1e-9, atol=1e-4)
+
+
+@pytest.mark.ci
+def test_dml_policytree_return_types(dml_policytree_fixture):
+    assert isinstance(dml_policytree_fixture['policytree_model'].__str__(), str)
+    assert isinstance(dml_policytree_fixture['policytree_model'].summary, pd.DataFrame)
+    assert isinstance(dml_policytree_fixture['policytree_model'].policy_tree, DecisionTreeClassifier)
+
+
+@pytest.mark.ci
+def test_doubleml_exception_policytree():
+    random_x_vars = pd.DataFrame(np.random.normal(0, 1, size=(2, 3)), columns=['a', 'b', 'c'])
+    signal = np.array([1, 2])
+
+    msg = "The signal must be of np.ndarray type. Signal of type <class 'int'> was passed."
+    with pytest.raises(TypeError, match=msg):
+        dml.DoubleMLPolicyTree(orth_signal=1, x_vars=random_x_vars)
+    msg = 'The signal must be of one dimensional. Signal of dimensions 2 was passed.'
+    with pytest.raises(ValueError, match=msg):
+        dml.DoubleMLPolicyTree(orth_signal=np.array([[1], [2]]), x_vars=random_x_vars)
+    msg = "The features must be of DataFrame type. Features of type <class 'int'> was passed."
+    with pytest.raises(TypeError, match=msg):
+        dml.DoubleMLPolicyTree(orth_signal=signal, x_vars=1)
+    msg = 'Invalid pd.DataFrame: Contains duplicate column names.'
+    with pytest.raises(ValueError, match=msg):
+        dml.DoubleMLPolicyTree(orth_signal=signal, x_vars=pd.DataFrame(np.array([[1, 2], [4, 5]]),
+                                                                columns=['a_1', 'a_1']))
+
+    dml_policytree_predict = dml.DoubleMLPolicyTree(orth_signal=signal, x_vars=random_x_vars)
+    msg = 'Policy Tree not yet fitted. Call fit before predict.'
+    with pytest.raises(NotFittedError, match=msg):
+        dml_policytree_predict.predict(random_x_vars)
+
+    dml_policytree_predict.fit()
+    msg = "The features must be of DataFrame type. Features of type <class 'int'> was passed."
+    with pytest.raises(TypeError, match=msg):
+        dml_policytree_predict.predict(x_vars=1)
+    msg = r'The features must have the keys Index\(\[\'a\', \'b\', \'c\'\], dtype\=\'object\'\). Features with keys Index\(\[\'d\'\], dtype=\'object\'\) were passed.'
+    with pytest.raises(KeyError, match=msg):
+        dml_policytree_predict.predict(x_vars=pd.DataFrame({"d": [3,4]}))
+
+    dml_policytree_plot = dml.DoubleMLPolicyTree(orth_signal=signal, x_vars=random_x_vars)
+    msg = 'Policy Tree not yet fitted. Call fit before plot_tree.'
+    with pytest.raises(NotFittedError, match=msg):
+        dml_policytree_plot.plot_tree()


### PR DESCRIPTION
With this PR I would like to add a Policy Tree implemenation.

### Description
- Adding a `DoubleMLPolicyTree` class that fits a weighted classification of arbitrary covariates on an orthogonal basis.
- Adding a `policy_tree()` method to the IRM model, that fits and returns a Policy Tree based on the ATE score.
- Adding unit tests for both the new class and the new method.

### Reference to Issues or PRs
Development of new features.

### PR Checklist

- [ ] The title of the pull request summarizes the changes made.
- [ ] The PR contains a detailed description of all changes and additions.
- [ ] References to related issues or PRs are added.
- [ ] The code passes all (unit) tests.
- [ ] Enhancements or new feature are equipped with unit tests.
- [ ] The changes adhere to the PEP8 standards.
