### PR TITLE
Add deprecation warnings

### DIFF
--- a/doubleml/_utils_resampling.py
+++ b/doubleml/_utils_resampling.py
@@ -25,7 +25,6 @@ class DoubleMLResampling:
         self.n_obs = n_obs
         if not apply_cross_fitting:
             deprication_apply_cross_fitting()
-            apply_cross_fitting = True
         self.apply_cross_fitting = apply_cross_fitting
         self.stratify = stratify
         if (self.n_folds == 1) & self.apply_cross_fitting:

--- a/doubleml/_utils_resampling.py
+++ b/doubleml/_utils_resampling.py
@@ -4,6 +4,15 @@ import warnings
 from sklearn.model_selection import KFold, RepeatedKFold, RepeatedStratifiedKFold
 
 
+# Remove warnings in future versions
+def deprication_apply_cross_fitting():
+    warnings.warn('The apply_cross_fitting argument is deprecated and will be removed in future versions. '
+                  'In the future, crossfitting is applied by default. '
+                  'To rely on sample splitting please use external predictions.',
+                  DeprecationWarning)
+    return
+
+
 class DoubleMLResampling:
     def __init__(self,
                  n_folds,
@@ -14,6 +23,9 @@ class DoubleMLResampling:
         self.n_folds = n_folds
         self.n_rep = n_rep
         self.n_obs = n_obs
+        if not apply_cross_fitting:
+            deprication_apply_cross_fitting()
+            apply_cross_fitting = True
         self.apply_cross_fitting = apply_cross_fitting
         self.stratify = stratify
         if (self.n_folds == 1) & self.apply_cross_fitting:

--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -24,6 +24,21 @@ from ._utils_plots import _sensitivity_contour_plot
 _implemented_data_backends = ['DoubleMLData', 'DoubleMLClusterData']
 
 
+# Remove warnings in future versions
+def deprication_apply_cross_fitting():
+    warnings.warn('The apply_cross_fitting argument is deprecated and will be removed in future versions. '
+                  'In the future, crossfitting is applied by default. '
+                  'To rely on sample splitting please use external predictions.',
+                  DeprecationWarning)
+    return
+
+
+def deprication_dml_procedure():
+    warnings.warn('The dml_procedure argument is deprecated and will be removed in future versions. '
+                  'in the future, dml_procedure is always set to dml2.', DeprecationWarning)
+    return
+
+
 class DoubleML(ABC):
     """Double Machine Learning.
     """
@@ -89,6 +104,9 @@ class DoubleML(ABC):
             raise TypeError('draw_sample_splitting must be True or False. '
                             f'Got {str(draw_sample_splitting)}.')
 
+        if not apply_cross_fitting:
+            deprication_apply_cross_fitting()
+
         # set resampling specifications
         if self._is_cluster_data:
             if (n_folds == 1) or (not apply_cross_fitting):
@@ -103,11 +121,15 @@ class DoubleML(ABC):
         # default is no stratification
         self._strata = None
 
-        # check and set dml_procedure and score
         if (not isinstance(dml_procedure, str)) | (dml_procedure not in ['dml1', 'dml2']):
             raise ValueError('dml_procedure must be "dml1" or "dml2". '
                              f'Got {str(dml_procedure)}.')
         self._dml_procedure = dml_procedure
+
+        if dml_procedure == 'dml1':
+            deprication_dml_procedure()
+        self._dml_procedure = dml_procedure
+
         self._score = score
 
         if (self.n_folds == 1) & self.apply_cross_fitting:


### PR DESCRIPTION
### Description
Adding deprication warnings for `dml_procedure` and `apply_cross_fitting`.
Both arguments will be removed from the `DoubleML` in the future. Instead `dml2` will be the standard method and crossfitting is automatically applied.
To still use non crossfitted learners `external_predictions` can be used in `fit()`.

### PR Checklist

- [ ] The title of the pull request summarizes the changes made.
- [ ] The PR contains a detailed description of all changes and additions.
- [ ] References to related issues or PRs are added.
- [ ] The code passes all (unit) tests.
- [ ] Enhancements or new feature are equipped with unit tests.
- [ ] The changes adhere to the PEP8 standards.
