### PR TITLE
Add Gain statistics and weights for ATTE

### DIFF
--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -272,7 +272,7 @@ class DoubleML(ABC):
     @property
     def predictions(self):
         """
-        The predictions of the nuisance models.
+        The predictions of the nuisance models with shape ``(n_obs, n_rep, n_coefs)``.
         """
         return self._predictions
 
@@ -354,6 +354,7 @@ class DoubleML(ABC):
         Values of the score function after calling :meth:`fit`;
         For models (e.g., PLR, IRM, PLIV, IIVM) with linear score (in the parameter)
         :math:`\\psi(W; \\theta, \\eta) = \\psi_a(W; \\eta) \\theta + \\psi_b(W; \\eta)`.
+        The shape is ``(n_obs, n_rep, n_coefs)``.
         """
         return self._psi
 
@@ -364,6 +365,7 @@ class DoubleML(ABC):
         after calling :meth:`fit`;
         For models (e.g., PLR, IRM, PLIV, IIVM) with linear score (in the parameter)
         :math:`\\psi_a(W; \\eta)`.
+        The shape is ``(n_obs, n_rep, n_coefs)``.
         """
         return self._psi_deriv
 

--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -272,7 +272,8 @@ class DoubleML(ABC):
     @property
     def predictions(self):
         """
-        The predictions of the nuisance models with shape ``(n_obs, n_rep, n_coefs)``.
+        The predictions of the nuisance models in form of a dictinary.
+        Each key refers to a nuisance element with a array of values of shape ``(n_obs, n_rep, n_coefs)``.
         """
         return self._predictions
 

--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -19,7 +19,7 @@ from ._utils import _draw_weights, _rmse, _aggregate_coefs_and_ses, _var_est
 from ._utils_checks import _check_in_zero_one, _check_integer, _check_float, _check_bool, _check_is_partition, \
     _check_all_smpls, _check_smpl_split, _check_smpl_split_tpl, _check_benchmarks
 from ._utils_plots import _sensitivity_contour_plot
-
+from .utils.gain_statistics import gain_statistics
 
 _implemented_data_backends = ['DoubleMLData', 'DoubleMLClusterData']
 
@@ -1997,45 +1997,6 @@ class DoubleML(ABC):
         dml_short._dml_data.x_cols = x_list_short
         dml_short.fit()
 
-        # save elements for readability
-        var_y = np.var(self._dml_data.y)
-        var_y_residuals_long = np.squeeze(self.sensitivity_elements['sigma2'], axis=0)
-        nu2_long = np.squeeze(self.sensitivity_elements['nu2'], axis=0)
-        var_y_residuals_short = np.squeeze(dml_short.sensitivity_elements['sigma2'], axis=0)
-        nu2_short = np.squeeze(dml_short.sensitivity_elements['nu2'], axis=0)
-
-        # compute nonparametric R2
-        R2_y_long = 1.0 - np.divide(var_y_residuals_long, var_y)
-        R2_y_short = 1.0 - np.divide(var_y_residuals_short, var_y)
-        R2_riesz = np.divide(nu2_short, nu2_long)
-
-        # Gain statistics
-        all_cf_y_benchmark = np.clip(np.divide((R2_y_long - R2_y_short), (1.0 - R2_y_long)), 0, 1)
-        all_cf_d_benchmark = np.clip(np.divide((1.0 - R2_riesz), R2_riesz), 0, 1)
-        cf_y_benchmark = np.median(all_cf_y_benchmark, axis=0)
-        cf_d_benchmark = np.median(all_cf_d_benchmark, axis=0)
-
-        # change in estimates (slightly different to paper)
-        all_delta_theta = np.transpose(dml_short.all_coef - self.all_coef)
-        delta_theta = np.median(all_delta_theta, axis=0)
-
-        # degree of adversity
-        var_g = var_y_residuals_short - var_y_residuals_long
-        var_riesz = nu2_long - nu2_short
-        denom = np.sqrt(np.multiply(var_g, var_riesz), out=np.zeros_like(var_g), where=(var_g > 0) & (var_riesz > 0))
-        rho_sign = np.sign(all_delta_theta)
-        rho_values = np.clip(np.divide(np.absolute(all_delta_theta),
-                                       denom,
-                                       out=np.ones_like(all_delta_theta),
-                                       where=denom != 0),
-                             0.0, 1.0)
-        all_rho_benchmark = np.multiply(rho_values, rho_sign)
-        rho_benchmark = np.median(all_rho_benchmark, axis=0)
-        benchmark_dict = {
-            "cf_y": cf_y_benchmark,
-            "cf_d": cf_d_benchmark,
-            "rho": rho_benchmark,
-            "delta_theta": delta_theta,
-        }
+        benchmark_dict = gain_statistics(dml_long=self, dml_short=dml_short)
         df_benchmark = pd.DataFrame(benchmark_dict, index=self._dml_data.d_cols)
         return df_benchmark

--- a/doubleml/double_ml_irm.py
+++ b/doubleml/double_ml_irm.py
@@ -310,7 +310,7 @@ class DoubleMLIRM(LinearScoreMixin, DoubleML):
             # adjust target values to consider only compatible subsamples
             g_hat1['targets'] = _cond_targets(g_hat1['targets'], cond_sample=(d == 1))
 
-        if self._dml_data.binary_outcome:
+        if self._dml_data.binary_outcome & (self.score != 'ATTE'):
             binary_preds = (type_of_target(g_hat1['preds']) == 'binary')
             zero_one_preds = np.all((np.power(g_hat1['preds'], 2) - g_hat1['preds']) == 0)
             if binary_preds & zero_one_preds:

--- a/doubleml/double_ml_irm.py
+++ b/doubleml/double_ml_irm.py
@@ -379,7 +379,7 @@ class DoubleMLIRM(LinearScoreMixin, DoubleML):
                 psi_a = np.full_like(m_hat_adj, -1.0)
             else:
                 assert self.score == 'ATTE'
-                psi_a = -1.0 * np.divide(d, np.mean(d))
+                psi_a = -1.0 * weights
         else:
             assert callable(self.score)
             psi_a, psi_b = self.score(y=y, d=d,

--- a/doubleml/double_ml_irm.py
+++ b/doubleml/double_ml_irm.py
@@ -291,8 +291,13 @@ class DoubleMLIRM(LinearScoreMixin, DoubleML):
                                      f'predictions obtained with the ml_g learner {str(self._learner["ml_g"])} are also '
                                      'observed to be binary with values 0 and 1. Make sure that for classifiers '
                                      'probabilities and not labels are predicted.')
+        if self.score == 'ATTE':
+            # skip g_hat1 estimation
+            g_hat1 = {'preds': None,
+                      'targets': None,
+                      'models': None}
 
-        if g1_external:
+        elif g1_external:
             # use external predictions
             g_hat1 = {'preds': external_predictions['ml_g1'],
                       'targets': None,

--- a/doubleml/tests/_utils_irm_manual.py
+++ b/doubleml/tests/_utils_irm_manual.py
@@ -298,7 +298,11 @@ def fit_sensitivity_elements_irm(y, d, all_coef, predictions, score, n_rep):
 
         m_hat = predictions['ml_m'][:, i_rep, 0]
         g_hat0 = predictions['ml_g0'][:, i_rep, 0]
-        g_hat1 = predictions['ml_g1'][:, i_rep, 0]
+        if score == 'ATE':
+            g_hat1 = predictions['ml_g1'][:, i_rep, 0]
+        else:
+            assert score == 'ATTE'
+            g_hat1 = y
 
         if score == 'ATE':
             weights = np.ones_like(d)

--- a/doubleml/tests/test_doubleml_exceptions.py
+++ b/doubleml/tests/test_doubleml_exceptions.py
@@ -428,16 +428,17 @@ def test_doubleml_exception_trimming_rule():
 
 @pytest.mark.ci
 def test_doubleml_exception_weights():
-    msg = "weights can only be set for score type 'ATE'. ATTE was passed."
-    with pytest.raises(NotImplementedError, match=msg):
-        _ = DoubleMLIRM(dml_data_irm, Lasso(), LogisticRegression(),
-                        score='ATTE', weights=np.ones_like(dml_data_irm.d))
+
     msg = "weights must be a numpy array or dictionary. weights of type <class 'int'> was passed."
     with pytest.raises(TypeError, match=msg):
         _ = DoubleMLIRM(dml_data_irm, Lasso(), LogisticRegression(), weights=1)
     msg = r"weights must have keys \['weights', 'weights_bar'\]. keys dict_keys\(\['d'\]\) were passed."
     with pytest.raises(ValueError, match=msg):
         _ = DoubleMLIRM(dml_data_irm, Lasso(), LogisticRegression(), weights={'d': [1, 2, 3]})
+    msg = "weights must be a numpy array for ATTE score. weights of type <class 'dict'> was passed."
+    with pytest.raises(TypeError, match=msg):
+        _ = DoubleMLIRM(dml_data_irm, Lasso(), LogisticRegression(),
+                        score='ATTE', weights={'weights': np.ones_like(dml_data_irm.d)})
 
     # shape checks
     msg = rf"weights must have shape \({n},\). weights of shape \(1,\) was passed."
@@ -484,6 +485,11 @@ def test_doubleml_exception_weights():
         _ = DoubleMLIRM(dml_data_irm, Lasso(), LogisticRegression(),
                         weights={'weights': np.ones((dml_data_irm.d.shape[0], )),
                                  'weights_bar': np.zeros((dml_data_irm.d.shape[0], 1))})
+
+    msg = "weights must be binary for ATTE score."
+    with pytest.raises(ValueError, match=msg):
+        _ = DoubleMLIRM(dml_data_irm, Lasso(), LogisticRegression(),
+                        score='ATTE', weights=np.random.choice([0, 0.2], dml_data_irm.d.shape[0]))
 
 
 @pytest.mark.ci

--- a/doubleml/tests/test_irm.py
+++ b/doubleml/tests/test_irm.py
@@ -278,7 +278,7 @@ def dml_irm_weights_fixture(n_rep, dml_procedure):
 
     # First stage estimation
     ml_g = LinearRegression()
-    ml_m = LogisticRegression(penalty='none', random_state=42)
+    ml_m = LogisticRegression(penalty='l2', random_state=42)
 
     # ATE with and without weights
     dml_irm_obj_ate_no_weights = dml.DoubleMLIRM(

--- a/doubleml/tests/test_irm_weighted_scores.py
+++ b/doubleml/tests/test_irm_weighted_scores.py
@@ -1,0 +1,117 @@
+import pytest
+import numpy as np
+
+from sklearn.base import clone
+from sklearn.linear_model import LogisticRegression, LinearRegression
+from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+
+import doubleml as dml
+
+from .._utils import _normalize_ipw
+
+
+def old_score_elements(y, d, g_hat0, g_hat1, m_hat, score, normalize_ipw):
+    # fraction of treated for ATTE
+    p_hat = None
+    if score == 'ATTE':
+        p_hat = np.mean(d)
+
+    if normalize_ipw:
+        m_hat = _normalize_ipw(m_hat, d)
+
+    # compute residuals
+    u_hat0 = y - g_hat0
+    u_hat1 = None
+    if score == 'ATE':
+        u_hat1 = y - g_hat1
+
+    if isinstance(score, str):
+        if score == 'ATE':
+            psi_b = g_hat1 - g_hat0 \
+                + np.divide(np.multiply(d, u_hat1), m_hat) \
+                - np.divide(np.multiply(1.0-d, u_hat0), 1.0 - m_hat)
+            psi_a = np.full_like(m_hat, -1.0)
+        else:
+            assert score == 'ATTE'
+            psi_b = np.divide(np.multiply(d, u_hat0), p_hat) \
+                - np.divide(np.multiply(m_hat, np.multiply(1.0-d, u_hat0)),
+                            np.multiply(p_hat, (1.0 - m_hat)))
+            psi_a = - np.divide(d, p_hat)
+
+    return psi_a, psi_b
+
+
+@pytest.fixture(scope='module',
+                params=[[LinearRegression(),
+                         LogisticRegression(solver='lbfgs', max_iter=250)],
+                        [RandomForestRegressor(max_depth=5, n_estimators=10, random_state=42),
+                         RandomForestClassifier(max_depth=5, n_estimators=10, random_state=42)]])
+def learner(request):
+    return request.param
+
+
+@pytest.fixture(scope='module',
+                params=['ATE', 'ATTE'])
+def score(request):
+    return request.param
+
+
+@pytest.fixture(scope='module',
+                params=[False, True])
+def normalize_ipw(request):
+    return request.param
+
+
+@pytest.fixture(scope='module',
+                params=[0.2, 0.15])
+def trimming_threshold(request):
+    return request.param
+
+
+@pytest.fixture(scope='module')
+def old_vs_weighted_score_fixture(generate_data_irm, learner, score, normalize_ipw, trimming_threshold):
+    n_folds = 2
+
+    # collect data
+    (x, y, d) = generate_data_irm
+    obj_dml_data = dml.DoubleMLData.from_arrays(x, y, d)
+
+    # Set machine learning methods for m & g
+    ml_g = clone(learner[0])
+    ml_m = clone(learner[1])
+
+    np.random.seed(3141)
+    dml_irm_obj = dml.DoubleMLIRM(obj_dml_data,
+                                  ml_g, ml_m,
+                                  n_folds,
+                                  score=score,
+                                  normalize_ipw=normalize_ipw,
+                                  trimming_threshold=trimming_threshold)
+    dml_irm_obj.fit()
+
+    # old score
+    psi_a_old, psi_b_old = old_score_elements(
+        y=y,
+        d=d,
+        g_hat0=np.squeeze(dml_irm_obj.predictions['ml_g0']),
+        g_hat1=np.squeeze(dml_irm_obj.predictions['ml_g1']),
+        m_hat=np.squeeze(dml_irm_obj.predictions['ml_m']),
+        score=score,
+        normalize_ipw=normalize_ipw
+    )
+
+    result_dict = {
+        'psi_a': np.squeeze(dml_irm_obj.psi_elements['psi_a']),
+        'psi_b': np.squeeze(dml_irm_obj.psi_elements['psi_b']),
+        'psi_a_old': psi_a_old,
+        'psi_b_old': psi_b_old,
+    }
+    return result_dict
+
+
+@pytest.mark.ci
+def test_irm_old_vs_weighted_score(old_vs_weighted_score_fixture):
+    assert np.allclose(old_vs_weighted_score_fixture['psi_a'],
+                       old_vs_weighted_score_fixture['psi_a_old'])
+    assert np.allclose(old_vs_weighted_score_fixture['psi_b'],
+                       old_vs_weighted_score_fixture['psi_b_old'])

--- a/doubleml/tests/test_irm_weighted_scores.py
+++ b/doubleml/tests/test_irm_weighted_scores.py
@@ -25,18 +25,17 @@ def old_score_elements(y, d, g_hat0, g_hat1, m_hat, score, normalize_ipw):
     if score == 'ATE':
         u_hat1 = y - g_hat1
 
-    if isinstance(score, str):
-        if score == 'ATE':
-            psi_b = g_hat1 - g_hat0 \
-                + np.divide(np.multiply(d, u_hat1), m_hat) \
-                - np.divide(np.multiply(1.0-d, u_hat0), 1.0 - m_hat)
-            psi_a = np.full_like(m_hat, -1.0)
-        else:
-            assert score == 'ATTE'
-            psi_b = np.divide(np.multiply(d, u_hat0), p_hat) \
-                - np.divide(np.multiply(m_hat, np.multiply(1.0-d, u_hat0)),
-                            np.multiply(p_hat, (1.0 - m_hat)))
-            psi_a = - np.divide(d, p_hat)
+    if score == 'ATE':
+        psi_b = g_hat1 - g_hat0 \
+            + np.divide(np.multiply(d, u_hat1), m_hat) \
+            - np.divide(np.multiply(1.0-d, u_hat0), 1.0 - m_hat)
+        psi_a = np.full_like(m_hat, -1.0)
+    else:
+        assert score == 'ATTE'
+        psi_b = np.divide(np.multiply(d, u_hat0), p_hat) \
+            - np.divide(np.multiply(m_hat, np.multiply(1.0-d, u_hat0)),
+                        np.multiply(p_hat, (1.0 - m_hat)))
+        psi_a = - np.divide(d, p_hat)
 
     return psi_a, psi_b
 

--- a/doubleml/tests/test_irm_weighted_scores.py
+++ b/doubleml/tests/test_irm_weighted_scores.py
@@ -25,6 +25,8 @@ def old_score_elements(y, d, g_hat0, g_hat1, m_hat, score, normalize_ipw):
     if score == 'ATE':
         u_hat1 = y - g_hat1
 
+    psi_a = np.full_like(y, np.nan)
+    psi_b = np.full_like(y, np.nan)
     if score == 'ATE':
         psi_b = g_hat1 - g_hat0 \
             + np.divide(np.multiply(d, u_hat1), m_hat) \

--- a/doubleml/tests/test_irm_weighted_scores.py
+++ b/doubleml/tests/test_irm_weighted_scores.py
@@ -100,18 +100,32 @@ def old_vs_weighted_score_fixture(generate_data_irm, learner, score, normalize_i
         normalize_ipw=normalize_ipw
     )
 
+    old_coef = -np.mean(psi_b_old) / np.mean(psi_a_old)
+
     result_dict = {
         'psi_a': np.squeeze(dml_irm_obj.psi_elements['psi_a']),
         'psi_b': np.squeeze(dml_irm_obj.psi_elements['psi_b']),
         'psi_a_old': psi_a_old,
         'psi_b_old': psi_b_old,
+        'coef': np.squeeze(dml_irm_obj.coef),
+        'old_coef': old_coef,
     }
     return result_dict
 
 
 @pytest.mark.ci
-def test_irm_old_vs_weighted_score(old_vs_weighted_score_fixture):
-    assert np.allclose(old_vs_weighted_score_fixture['psi_a'],
-                       old_vs_weighted_score_fixture['psi_a_old'])
+def test_irm_old_vs_weighted_score_psi_b(old_vs_weighted_score_fixture):
     assert np.allclose(old_vs_weighted_score_fixture['psi_b'],
                        old_vs_weighted_score_fixture['psi_b_old'])
+
+
+@pytest.mark.ci
+def test_irm_old_vs_weighted_score_psi_a(old_vs_weighted_score_fixture):
+    assert np.allclose(old_vs_weighted_score_fixture['psi_a'],
+                       old_vs_weighted_score_fixture['psi_a_old'])
+
+
+@pytest.mark.ci
+def test_irm_old_vs_weighted_coef(old_vs_weighted_score_fixture):
+    assert np.allclose(old_vs_weighted_score_fixture['coef'],
+                       old_vs_weighted_score_fixture['old_coef'])

--- a/doubleml/utils/__init__.py
+++ b/doubleml/utils/__init__.py
@@ -1,7 +1,9 @@
 from .dummy_learners import DMLDummyRegressor
 from .dummy_learners import DMLDummyClassifier
+from .gain_statistics import gain_statistics
 
 __all__ = [
     "DMLDummyRegressor",
     "DMLDummyClassifier",
+    "gain_statistics"
 ]

--- a/doubleml/utils/dummy_learners.py
+++ b/doubleml/utils/dummy_learners.py
@@ -5,10 +5,12 @@ class DMLDummyRegressor(BaseEstimator):
     """
     A dummy regressor that raises an AttributeError when attempting to access
     its fit, predict, or set_params methods.
+
     Attributes
     ----------
     _estimator_type : str
         Type of the estimator, set to "regressor".
+
     Methods
     -------
     fit(*args)
@@ -35,10 +37,12 @@ class DMLDummyClassifier(BaseEstimator):
     """
     A dummy classifier that raises an AttributeError when attempting to access
     its fit, predict, set_params, or predict_proba methods.
+
     Attributes
     ----------
     _estimator_type : str
         Type of the estimator, set to "classifier".
+
     Methods
     -------
     fit(*args)

--- a/doubleml/utils/gain_statistics.py
+++ b/doubleml/utils/gain_statistics.py
@@ -17,10 +17,16 @@ def gain_statistics(dml_long, dml_short):
     Benchmarking dictionary (dict) with values for cf_d, cf_y, rho, and delta_theta.
 
     """
+    if not isinstance(dml_long.sensitivity_elements, dict):
+        raise TypeError("dml_long does not contain the necessary sensitivity elements. "
+                        "Expected dict for dml_long.sensitivity_elements.")
     expected_keys = ['sigma2', 'nu2']
     if not all(key in dml_long.sensitivity_elements.keys() for key in expected_keys):
         raise ValueError("dml_long does not contain the necessary sensitivity elements. "
                          "Required keys are: " + str(expected_keys))
+    if not isinstance(dml_short.sensitivity_elements, dict):
+        raise TypeError("dml_short does not contain the necessary sensitivity elements. "
+                        "Expected dict for dml_short.sensitivity_elements.")
     if not all(key in dml_short.sensitivity_elements.keys() for key in expected_keys):
         raise ValueError("dml_short does not contain the necessary sensitivity elements. "
                          "Required keys are: " + str(expected_keys))
@@ -32,6 +38,12 @@ def gain_statistics(dml_long, dml_short):
         if not isinstance(dml_short.sensitivity_elements[key], np.ndarray):
             raise TypeError("dml_short does not contain the necessary sensitivity elements. "
                             f"Expected numpy.ndarray for key {key}.")
+        if len(dml_long.sensitivity_elements[key].shape) != 3 or dml_long.sensitivity_elements[key].shape[0] != 1:
+            raise ValueError("dml_long does not contain the necessary sensitivity elements. "
+                             f"Expected 3 dimensions of shape (1, n_coef, n_rep) for key {key}.")
+        if len(dml_short.sensitivity_elements[key].shape) != 3 or dml_short.sensitivity_elements[key].shape[0] != 1:
+            raise ValueError("dml_short does not contain the necessary sensitivity elements. "
+                             f"Expected 3 dimensions of shape (1, n_coef, n_rep) for key {key}.")
         if not np.array_equal(dml_long.sensitivity_elements[key].shape, dml_short.sensitivity_elements[key].shape):
             raise ValueError("dml_long and dml_short do not contain the same shape of sensitivity elements. "
                              "Shapes of " + key + " are: " + str(dml_long.sensitivity_elements[key].shape) +
@@ -41,6 +53,14 @@ def gain_statistics(dml_long, dml_short):
         raise TypeError("dml_long.all_coef does not contain the necessary coefficients. Expected numpy.ndarray.")
     if not isinstance(dml_short.all_coef, np.ndarray):
         raise TypeError("dml_short.all_coef does not contain the necessary coefficients. Expected numpy.ndarray.")
+
+    expected_shape = (dml_long.sensitivity_elements['sigma2'].shape[1], dml_long.sensitivity_elements['sigma2'].shape[2])
+    if dml_long.all_coef.shape != expected_shape:
+        raise ValueError("dml_long.all_coef does not contain the necessary coefficients. Expected shape: " +
+                         str(expected_shape))
+    if dml_short.all_coef.shape != expected_shape:
+        raise ValueError("dml_short.all_coef does not contain the necessary coefficients. Expected shape: " +
+                         str(expected_shape))
 
     # save elements for readability
     var_y = np.var(dml_long._dml_data.y)

--- a/doubleml/utils/gain_statistics.py
+++ b/doubleml/utils/gain_statistics.py
@@ -1,0 +1,85 @@
+import numpy as np
+
+
+def gain_statistics(dml_long, dml_short):
+    """
+    Compute gain statistics as benchmark values for sensitivity parameters cf_d and cf_y.
+
+    Parameters:
+    ----------
+
+    dml_long : :class:`doubleml.DoubleML` model including all observed confounders
+    dml_short : :class:`doubleml.DoubleML` model that excludes one or several benchmark confounders
+
+
+    Returns:
+    --------
+    Benchmarking dictionary (dict) with values for cf_d, cf_y, rho, and delta_theta.
+
+    """
+    expected_keys = ['sigma2', 'nu2']
+    if not all(key in dml_long.sensitivity_elements.keys() for key in expected_keys):
+        raise ValueError("dml_long does not contain the necessary sensitivity elements. "
+                         "Required keys are: " + str(expected_keys))
+    if not all(key in dml_short.sensitivity_elements.keys() for key in expected_keys):
+        raise ValueError("dml_short does not contain the necessary sensitivity elements. "
+                         "Required keys are: " + str(expected_keys))
+
+    for key in expected_keys:
+        if not isinstance(dml_long.sensitivity_elements[key], np.ndarray):
+            raise TypeError("dml_long does not contain the necessary sensitivity elements. "
+                            f"Expected numpy.ndarray for key {key}.")
+        if not isinstance(dml_short.sensitivity_elements[key], np.ndarray):
+            raise TypeError("dml_short does not contain the necessary sensitivity elements. "
+                            f"Expected numpy.ndarray for key {key}.")
+        if not np.array_equal(dml_long.sensitivity_elements[key].shape, dml_short.sensitivity_elements[key].shape):
+            raise ValueError("dml_long and dml_short do not contain the same shape of sensitivity elements. "
+                             "Shapes of " + key + " are: " + str(dml_long.sensitivity_elements[key].shape) +
+                             " and " + str(dml_short.sensitivity_elements[key].shape))
+
+    if not isinstance(dml_long.all_coef, np.ndarray):
+        raise TypeError("dml_long.all_coef does not contain the necessary coefficients. Expected numpy.ndarray.")
+    if not isinstance(dml_short.all_coef, np.ndarray):
+        raise TypeError("dml_short.all_coef does not contain the necessary coefficients. Expected numpy.ndarray.")
+
+    # save elements for readability
+    var_y = np.var(dml_long._dml_data.y)
+    var_y_residuals_long = np.squeeze(dml_long.sensitivity_elements['sigma2'], axis=0)
+    nu2_long = np.squeeze(dml_long.sensitivity_elements['nu2'], axis=0)
+    var_y_residuals_short = np.squeeze(dml_short.sensitivity_elements['sigma2'], axis=0)
+    nu2_short = np.squeeze(dml_short.sensitivity_elements['nu2'], axis=0)
+
+    # compute nonparametric R2
+    R2_y_long = 1.0 - np.divide(var_y_residuals_long, var_y)
+    R2_y_short = 1.0 - np.divide(var_y_residuals_short, var_y)
+    R2_riesz = np.divide(nu2_short, nu2_long)
+
+    # Gain statistics
+    all_cf_y_benchmark = np.clip(np.divide((R2_y_long - R2_y_short), (1.0 - R2_y_long)), 0, 1)
+    all_cf_d_benchmark = np.clip(np.divide((1.0 - R2_riesz), R2_riesz), 0, 1)
+    cf_y_benchmark = np.median(all_cf_y_benchmark, axis=0)
+    cf_d_benchmark = np.median(all_cf_d_benchmark, axis=0)
+
+    # change in estimates (slightly different to paper)
+    all_delta_theta = np.transpose(dml_short.all_coef - dml_long.all_coef)
+    delta_theta = np.median(all_delta_theta, axis=0)
+
+    # degree of adversity
+    var_g = var_y_residuals_short - var_y_residuals_long
+    var_riesz = nu2_long - nu2_short
+    denom = np.sqrt(np.multiply(var_g, var_riesz), out=np.zeros_like(var_g), where=(var_g > 0) & (var_riesz > 0))
+    rho_sign = np.sign(all_delta_theta)
+    rho_values = np.clip(np.divide(np.absolute(all_delta_theta),
+                                   denom,
+                                   out=np.ones_like(all_delta_theta),
+                                   where=denom != 0),
+                         0.0, 1.0)
+    all_rho_benchmark = np.multiply(rho_values, rho_sign)
+    rho_benchmark = np.median(all_rho_benchmark, axis=0)
+    benchmark_dict = {
+        "cf_y": cf_y_benchmark,
+        "cf_d": cf_d_benchmark,
+        "rho": rho_benchmark,
+        "delta_theta": delta_theta,
+    }
+    return benchmark_dict

--- a/doubleml/utils/gain_statistics.py
+++ b/doubleml/utils/gain_statistics.py
@@ -54,7 +54,7 @@ def gain_statistics(dml_long, dml_short):
     if not isinstance(dml_short.all_coef, np.ndarray):
         raise TypeError("dml_short.all_coef does not contain the necessary coefficients. Expected numpy.ndarray.")
 
-    expected_shape = (dml_long.sensitivity_elements['sigma2'].shape[1], dml_long.sensitivity_elements['sigma2'].shape[2])
+    expected_shape = (dml_long.sensitivity_elements['sigma2'].shape[2], dml_long.sensitivity_elements['sigma2'].shape[1])
     if dml_long.all_coef.shape != expected_shape:
         raise ValueError("dml_long.all_coef does not contain the necessary coefficients. Expected shape: " +
                          str(expected_shape))

--- a/doubleml/utils/tests/test_exceptions_gain_statistics.py
+++ b/doubleml/utils/tests/test_exceptions_gain_statistics.py
@@ -33,7 +33,8 @@ def test_doubleml_exception_data():
     msg = r"dml_long does not contain the necessary sensitivity elements\. Expected dict for dml_long\.sensitivity_elements\."
     with pytest.raises(TypeError, match=msg):
         _ = gain_statistics(dml_incorrect, dml_correct)
-    msg = r"dml_short does not contain the necessary sensitivity elements\. Expected dict for dml_short\.sensitivity_elements\."
+    msg = r"dml_short does not contain the necessary sensitivity elements\. "
+    msg += r"Expected dict for dml_short\.sensitivity_elements\."
     with pytest.raises(TypeError, match=msg):
         _ = gain_statistics(dml_correct, dml_incorrect)
 

--- a/doubleml/utils/tests/test_exceptions_gain_statistics.py
+++ b/doubleml/utils/tests/test_exceptions_gain_statistics.py
@@ -11,23 +11,23 @@ class test_dml_class():
 
 
 n_obs = 1
-n_rep = 5
-n_coef = 3
+n_rep = 3
+n_coef = 5
 
 
 @pytest.mark.ci
 def test_doubleml_exception_data():
     dml_correct = test_dml_class(
         sensitivity_elements={
-            'sigma2': np.random.normal(size=(n_obs, n_coef, n_rep)),
-            'nu2': np.random.normal(size=(n_obs, n_coef, n_rep))
+            'sigma2': np.random.normal(size=(n_obs, n_rep, n_coef)),
+            'nu2': np.random.normal(size=(n_obs, n_rep, n_coef))
         },
         all_coef=np.random.normal(size=(n_coef, n_rep))
     )
 
     # incorrect types
     dml_incorrect = test_dml_class(
-            sensitivity_elements=np.random.normal(size=(n_obs, n_coef, n_rep)),
+            sensitivity_elements=np.random.normal(size=(n_obs, n_rep, n_coef)),
             all_coef=np.random.normal(size=(n_coef, n_rep))
         )
     msg = r"dml_long does not contain the necessary sensitivity elements\. Expected dict for dml_long\.sensitivity_elements\."
@@ -41,7 +41,7 @@ def test_doubleml_exception_data():
     # incorrect keys
     dml_incorrect = test_dml_class(
             sensitivity_elements={
-                'sigma2': np.random.normal(size=(n_obs, n_coef, n_rep)),
+                'sigma2': np.random.normal(size=(n_obs, n_rep, n_coef)),
             },
             all_coef=np.random.normal(size=(n_coef, n_rep))
         )
@@ -56,7 +56,7 @@ def test_doubleml_exception_data():
     dml_incorrect = test_dml_class(
             sensitivity_elements={
                 'sigma2': {},
-                'nu2': np.random.normal(size=(n_obs, n_coef, n_rep))
+                'nu2': np.random.normal(size=(n_obs, n_rep, n_coef))
             },
             all_coef=np.random.normal(size=(n_coef, n_rep))
         )
@@ -69,7 +69,7 @@ def test_doubleml_exception_data():
 
     dml_incorrect = test_dml_class(
         sensitivity_elements={
-            'sigma2': np.random.normal(size=(n_obs, n_coef, n_rep)),
+            'sigma2': np.random.normal(size=(n_obs, n_rep, n_coef)),
             'nu2': {}
         },
         all_coef=np.random.normal(size=(n_coef, n_rep))
@@ -84,8 +84,8 @@ def test_doubleml_exception_data():
     # incorrect shape for keys
     dml_incorrect = test_dml_class(
             sensitivity_elements={
-                'sigma2': np.random.normal(size=(n_obs + 1, n_coef, n_rep)),
-                'nu2': np.random.normal(size=(n_obs, n_coef, n_rep))
+                'sigma2': np.random.normal(size=(n_obs + 1, n_rep, n_coef)),
+                'nu2': np.random.normal(size=(n_obs, n_rep, n_coef))
             },
             all_coef=np.random.normal(size=(n_coef, n_rep))
         )
@@ -100,8 +100,8 @@ def test_doubleml_exception_data():
 
     dml_incorrect = test_dml_class(
             sensitivity_elements={
-                'sigma2': np.random.normal(size=(n_obs, n_coef, n_rep)),
-                'nu2': np.random.normal(size=(n_obs + 1, n_coef, n_rep))
+                'sigma2': np.random.normal(size=(n_obs, n_rep, n_coef)),
+                'nu2': np.random.normal(size=(n_obs + 1, n_rep, n_coef))
             },
             all_coef=np.random.normal(size=(n_coef, n_rep))
         )
@@ -117,8 +117,8 @@ def test_doubleml_exception_data():
     # conflicting shape for keys
     dml_incorrect = test_dml_class(
             sensitivity_elements={
-                'sigma2': np.random.normal(size=(n_obs, n_coef + 1, n_rep)),
-                'nu2': np.random.normal(size=(n_obs, n_coef, n_rep))
+                'sigma2': np.random.normal(size=(n_obs, n_rep + 1, n_coef)),
+                'nu2': np.random.normal(size=(n_obs, n_rep, n_coef))
             },
             all_coef=np.random.normal(size=(n_coef, n_rep))
         )
@@ -133,8 +133,8 @@ def test_doubleml_exception_data():
 
     dml_incorrect = test_dml_class(
             sensitivity_elements={
-                'sigma2': np.random.normal(size=(n_obs, n_coef, n_rep)),
-                'nu2': np.random.normal(size=(n_obs, n_coef + 1, n_rep))
+                'sigma2': np.random.normal(size=(n_obs, n_rep, n_coef)),
+                'nu2': np.random.normal(size=(n_obs, n_rep + 1, n_coef))
             },
             all_coef=np.random.normal(size=(n_coef, n_rep))
         )
@@ -150,8 +150,8 @@ def test_doubleml_exception_data():
     # incorrect type for all_coef
     dml_incorrect = test_dml_class(
             sensitivity_elements={
-                'sigma2': np.random.normal(size=(n_obs, n_coef, n_rep)),
-                'nu2': np.random.normal(size=(n_obs, n_coef, n_rep))
+                'sigma2': np.random.normal(size=(n_obs, n_rep, n_coef)),
+                'nu2': np.random.normal(size=(n_obs, n_rep, n_coef))
             },
             all_coef={}
         )
@@ -165,14 +165,14 @@ def test_doubleml_exception_data():
     # incorrect shape for all_coef
     dml_incorrect = test_dml_class(
             sensitivity_elements={
-                'sigma2': np.random.normal(size=(n_obs, n_coef, n_rep)),
-                'nu2': np.random.normal(size=(n_obs, n_coef, n_rep))
+                'sigma2': np.random.normal(size=(n_obs, n_rep, n_coef)),
+                'nu2': np.random.normal(size=(n_obs, n_rep, n_coef))
             },
             all_coef=np.random.normal(size=(n_coef + 1, n_rep))
         )
-    msg = r"dml_long\.all_coef does not contain the necessary coefficients\. Expected shape: \(3, 5\)"
+    msg = r"dml_long\.all_coef does not contain the necessary coefficients\. Expected shape: \(5, 3\)"
     with pytest.raises(ValueError, match=msg):
         _ = gain_statistics(dml_incorrect, dml_correct)
-    msg = r"dml_short\.all_coef does not contain the necessary coefficients\. Expected shape: \(3, 5\)"
+    msg = r"dml_short\.all_coef does not contain the necessary coefficients\. Expected shape: \(5, 3\)"
     with pytest.raises(ValueError, match=msg):
         _ = gain_statistics(dml_correct, dml_incorrect)

--- a/doubleml/utils/tests/test_exceptions_gain_statistics.py
+++ b/doubleml/utils/tests/test_exceptions_gain_statistics.py
@@ -1,0 +1,177 @@
+import pytest
+import numpy as np
+
+from doubleml.utils.gain_statistics import gain_statistics
+
+
+class test_dml_class():
+    def __init__(self, sensitivity_elements, all_coef):
+        self.sensitivity_elements = sensitivity_elements
+        self.all_coef = all_coef
+
+
+n_obs = 1
+n_rep = 5
+n_coef = 3
+
+
+@pytest.mark.ci
+def test_doubleml_exception_data():
+    dml_correct = test_dml_class(
+        sensitivity_elements={
+            'sigma2': np.random.normal(size=(n_obs, n_coef, n_rep)),
+            'nu2': np.random.normal(size=(n_obs, n_coef, n_rep))
+        },
+        all_coef=np.random.normal(size=(n_coef, n_rep))
+    )
+
+    # incorrect types
+    dml_incorrect = test_dml_class(
+            sensitivity_elements=np.random.normal(size=(n_obs, n_coef, n_rep)),
+            all_coef=np.random.normal(size=(n_coef, n_rep))
+        )
+    msg = r"dml_long does not contain the necessary sensitivity elements\. Expected dict for dml_long\.sensitivity_elements\."
+    with pytest.raises(TypeError, match=msg):
+        _ = gain_statistics(dml_incorrect, dml_correct)
+    msg = r"dml_short does not contain the necessary sensitivity elements\. Expected dict for dml_short\.sensitivity_elements\."
+    with pytest.raises(TypeError, match=msg):
+        _ = gain_statistics(dml_correct, dml_incorrect)
+
+    # incorrect keys
+    dml_incorrect = test_dml_class(
+            sensitivity_elements={
+                'sigma2': np.random.normal(size=(n_obs, n_coef, n_rep)),
+            },
+            all_coef=np.random.normal(size=(n_coef, n_rep))
+        )
+    msg = r"dml_long does not contain the necessary sensitivity elements\. Required keys are: \['sigma2', 'nu2'\]"
+    with pytest.raises(ValueError, match=msg):
+        _ = gain_statistics(dml_incorrect, dml_correct)
+    msg = r"dml_short does not contain the necessary sensitivity elements\. Required keys are: \['sigma2', 'nu2'\]"
+    with pytest.raises(ValueError, match=msg):
+        _ = gain_statistics(dml_correct, dml_incorrect)
+
+    # incorrect type for keys
+    dml_incorrect = test_dml_class(
+            sensitivity_elements={
+                'sigma2': {},
+                'nu2': np.random.normal(size=(n_obs, n_coef, n_rep))
+            },
+            all_coef=np.random.normal(size=(n_coef, n_rep))
+        )
+    msg = r"dml_long does not contain the necessary sensitivity elements\. Expected numpy\.ndarray for key sigma2\."
+    with pytest.raises(TypeError, match=msg):
+        _ = gain_statistics(dml_incorrect, dml_correct)
+    msg = r"dml_short does not contain the necessary sensitivity elements\. Expected numpy\.ndarray for key sigma2\."
+    with pytest.raises(TypeError, match=msg):
+        _ = gain_statistics(dml_correct, dml_incorrect)
+
+    dml_incorrect = test_dml_class(
+        sensitivity_elements={
+            'sigma2': np.random.normal(size=(n_obs, n_coef, n_rep)),
+            'nu2': {}
+        },
+        all_coef=np.random.normal(size=(n_coef, n_rep))
+    )
+    msg = r"dml_long does not contain the necessary sensitivity elements\. Expected numpy\.ndarray for key nu2\."
+    with pytest.raises(TypeError, match=msg):
+        _ = gain_statistics(dml_incorrect, dml_correct)
+    msg = r"dml_short does not contain the necessary sensitivity elements\. Expected numpy\.ndarray for key nu2\."
+    with pytest.raises(TypeError, match=msg):
+        _ = gain_statistics(dml_correct, dml_incorrect)
+
+    # incorrect shape for keys
+    dml_incorrect = test_dml_class(
+            sensitivity_elements={
+                'sigma2': np.random.normal(size=(n_obs + 1, n_coef, n_rep)),
+                'nu2': np.random.normal(size=(n_obs, n_coef, n_rep))
+            },
+            all_coef=np.random.normal(size=(n_coef, n_rep))
+        )
+    msg = (r"dml_long does not contain the necessary sensitivity elements\. "
+           r"Expected 3 dimensions of shape \(1, n_coef, n_rep\) for key sigma2\.")
+    with pytest.raises(ValueError, match=msg):
+        _ = gain_statistics(dml_incorrect, dml_correct)
+    msg = (r"dml_short does not contain the necessary sensitivity elements\. "
+           r"Expected 3 dimensions of shape \(1, n_coef, n_rep\) for key sigma2\.")
+    with pytest.raises(ValueError, match=msg):
+        _ = gain_statistics(dml_correct, dml_incorrect)
+
+    dml_incorrect = test_dml_class(
+            sensitivity_elements={
+                'sigma2': np.random.normal(size=(n_obs, n_coef, n_rep)),
+                'nu2': np.random.normal(size=(n_obs + 1, n_coef, n_rep))
+            },
+            all_coef=np.random.normal(size=(n_coef, n_rep))
+        )
+    msg = (r"dml_long does not contain the necessary sensitivity elements\. "
+           r"Expected 3 dimensions of shape \(1, n_coef, n_rep\) for key nu2\.")
+    with pytest.raises(ValueError, match=msg):
+        _ = gain_statistics(dml_incorrect, dml_correct)
+    msg = (r"dml_short does not contain the necessary sensitivity elements\. "
+           r"Expected 3 dimensions of shape \(1, n_coef, n_rep\) for key nu2\.")
+    with pytest.raises(ValueError, match=msg):
+        _ = gain_statistics(dml_correct, dml_incorrect)
+
+    # conflicting shape for keys
+    dml_incorrect = test_dml_class(
+            sensitivity_elements={
+                'sigma2': np.random.normal(size=(n_obs, n_coef + 1, n_rep)),
+                'nu2': np.random.normal(size=(n_obs, n_coef, n_rep))
+            },
+            all_coef=np.random.normal(size=(n_coef, n_rep))
+        )
+    msg = r"dml_long and dml_short do not contain the same shape of sensitivity elements\. "
+    msg += r"Shapes of sigma2 are: \(1, 4, 5\) and \(1, 3, 5\)"
+    with pytest.raises(ValueError, match=msg):
+        _ = gain_statistics(dml_incorrect, dml_correct)
+    msg = r"dml_long and dml_short do not contain the same shape of sensitivity elements\. "
+    msg += r"Shapes of sigma2 are: \(1, 3, 5\) and \(1, 4, 5\)"
+    with pytest.raises(ValueError, match=msg):
+        _ = gain_statistics(dml_correct, dml_incorrect)
+
+    dml_incorrect = test_dml_class(
+            sensitivity_elements={
+                'sigma2': np.random.normal(size=(n_obs, n_coef, n_rep)),
+                'nu2': np.random.normal(size=(n_obs, n_coef + 1, n_rep))
+            },
+            all_coef=np.random.normal(size=(n_coef, n_rep))
+        )
+    msg = r"dml_long and dml_short do not contain the same shape of sensitivity elements\. "
+    msg += r"Shapes of nu2 are: \(1, 4, 5\) and \(1, 3, 5\)"
+    with pytest.raises(ValueError, match=msg):
+        _ = gain_statistics(dml_incorrect, dml_correct)
+    msg = r"dml_long and dml_short do not contain the same shape of sensitivity elements\. "
+    msg += r"Shapes of nu2 are: \(1, 3, 5\) and \(1, 4, 5\)"
+    with pytest.raises(ValueError, match=msg):
+        _ = gain_statistics(dml_correct, dml_incorrect)
+
+    # incorrect type for all_coef
+    dml_incorrect = test_dml_class(
+            sensitivity_elements={
+                'sigma2': np.random.normal(size=(n_obs, n_coef, n_rep)),
+                'nu2': np.random.normal(size=(n_obs, n_coef, n_rep))
+            },
+            all_coef={}
+        )
+    msg = r"dml_long\.all_coef does not contain the necessary coefficients\. Expected numpy\.ndarray\."
+    with pytest.raises(TypeError, match=msg):
+        _ = gain_statistics(dml_incorrect, dml_correct)
+    msg = r"dml_short\.all_coef does not contain the necessary coefficients\. Expected numpy\.ndarray\."
+    with pytest.raises(TypeError, match=msg):
+        _ = gain_statistics(dml_correct, dml_incorrect)
+
+    # incorrect shape for all_coef
+    dml_incorrect = test_dml_class(
+            sensitivity_elements={
+                'sigma2': np.random.normal(size=(n_obs, n_coef, n_rep)),
+                'nu2': np.random.normal(size=(n_obs, n_coef, n_rep))
+            },
+            all_coef=np.random.normal(size=(n_coef + 1, n_rep))
+        )
+    msg = r"dml_long\.all_coef does not contain the necessary coefficients\. Expected shape: \(3, 5\)"
+    with pytest.raises(ValueError, match=msg):
+        _ = gain_statistics(dml_incorrect, dml_correct)
+    msg = r"dml_short\.all_coef does not contain the necessary coefficients\. Expected shape: \(3, 5\)"
+    with pytest.raises(ValueError, match=msg):
+        _ = gain_statistics(dml_correct, dml_incorrect)


### PR DESCRIPTION
Add the computation of gain statistics to `utils` as `gain_statistics`.

Adding the option to set binary weights for `score="ATTE"` in `DoubleMLIRM` model.


Further, added shapes to several attribute descriptions.