### PR TITLE
Add Log Loss to nuisance evaluation

### DIFF
--- a/doubleml/did/did.py
+++ b/doubleml/did/did.py
@@ -161,7 +161,11 @@ class DoubleMLDID(LinearScoreMixin, DoubleML):
         return self._trimming_threshold
 
     def _initialize_ml_nuisance_params(self):
-        valid_learner = ['ml_g0', 'ml_g1', 'ml_m']
+        if self.score == 'observational':
+            valid_learner = ['ml_g0', 'ml_g1', 'ml_m']
+        else:
+            assert self.score == 'experimental'
+            valid_learner = ['ml_g0', 'ml_g1']
         self._params = {learner: {key: [None] * self.n_rep for key in self._dml_data.d_cols}
                         for learner in valid_learner}
 

--- a/doubleml/did/did_cs.py
+++ b/doubleml/did/did_cs.py
@@ -162,8 +162,13 @@ class DoubleMLDIDCS(LinearScoreMixin, DoubleML):
         return self._trimming_threshold
 
     def _initialize_ml_nuisance_params(self):
-        valid_learner = ['ml_g_d0_t0', 'ml_g_d0_t1',
-                         'ml_g_d1_t0', 'ml_g_d1_t1', 'ml_m']
+        if self.score == 'observational':
+            valid_learner = ['ml_g_d0_t0', 'ml_g_d0_t1',
+                             'ml_g_d1_t0', 'ml_g_d1_t1', 'ml_m']
+        else:
+            assert self.score == 'experimental'
+            valid_learner = ['ml_g_d0_t0', 'ml_g_d0_t1',
+                             'ml_g_d1_t0', 'ml_g_d1_t1']
         self._params = {learner: {key: [None] * self.n_rep for key in self._dml_data.d_cols}
                         for learner in valid_learner}
 

--- a/doubleml/did/tests/_utils_did_cs_manual.py
+++ b/doubleml/did/tests/_utils_did_cs_manual.py
@@ -285,7 +285,6 @@ def fit_sensitivity_elements_did_cs(y, d, t, all_coef, predictions, score, in_sa
 
     for i_rep in range(n_rep):
 
-        m_hat = predictions['ml_m'][:, i_rep, 0]
         g_hat_d0_t0 = predictions['ml_g_d0_t0'][:, i_rep, 0]
         g_hat_d0_t1 = predictions['ml_g_d0_t1'][:, i_rep, 0]
         g_hat_d1_t0 = predictions['ml_g_d1_t0'][:, i_rep, 0]
@@ -305,6 +304,7 @@ def fit_sensitivity_elements_did_cs(y, d, t, all_coef, predictions, score, in_sa
         p_hat = np.mean(d)
         lambda_hat = np.mean(t)
         if score == 'observational':
+            m_hat = predictions['ml_m'][:, i_rep, 0]
             propensity_weight_d0 = np.divide(m_hat, 1.0-m_hat)
             if in_sample_normalization:
                 weight_d0t1 = np.multiply(d0t1, propensity_weight_d0)

--- a/doubleml/did/tests/_utils_did_manual.py
+++ b/doubleml/did/tests/_utils_did_manual.py
@@ -220,7 +220,6 @@ def fit_sensitivity_elements_did(y, d, all_coef, predictions, score, in_sample_n
 
     for i_rep in range(n_rep):
 
-        m_hat = predictions['ml_m'][:, i_rep, 0]
         g_hat0 = predictions['ml_g0'][:, i_rep, 0]
         g_hat1 = predictions['ml_g1'][:, i_rep, 0]
 
@@ -229,6 +228,7 @@ def fit_sensitivity_elements_did(y, d, all_coef, predictions, score, in_sample_n
         psi_sigma2[:, i_rep, 0] = sigma2_score_element - sigma2[0, i_rep, 0]
 
         if score == 'observational':
+            m_hat = predictions['ml_m'][:, i_rep, 0]
             propensity_weight_d0 = np.divide(m_hat, 1.0-m_hat)
             if in_sample_normalization:
                 m_alpha_1 = np.divide(d, np.mean(d))

--- a/doubleml/did/tests/test_did_cs_external_predictions.py
+++ b/doubleml/did/tests/test_did_cs_external_predictions.py
@@ -39,7 +39,8 @@ def doubleml_didcs_fixture(did_score, n_rep):
     ext_predictions["d"]["ml_g_d0_t1"] = dml_did_cs.predictions["ml_g_d0_t1"][:, :, 0]
     ext_predictions["d"]["ml_g_d1_t0"] = dml_did_cs.predictions["ml_g_d1_t0"][:, :, 0]
     ext_predictions["d"]["ml_g_d1_t1"] = dml_did_cs.predictions["ml_g_d1_t1"][:, :, 0]
-    ext_predictions["d"]["ml_m"] = dml_did_cs.predictions["ml_m"][:, :, 0]
+    if did_score == "observational":
+        ext_predictions["d"]["ml_m"] = dml_did_cs.predictions["ml_m"][:, :, 0]
 
     dml_did_cs_ext = DoubleMLDIDCS(ml_g=DMLDummyRegressor(), ml_m=DMLDummyClassifier(), **kwargs)
     dml_did_cs_ext.set_sample_splitting(all_smpls)

--- a/doubleml/did/tests/test_did_external_predictions.py
+++ b/doubleml/did/tests/test_did_external_predictions.py
@@ -36,7 +36,8 @@ def doubleml_did_fixture(did_score, n_rep):
 
     ext_predictions["d"]["ml_g0"] = dml_did.predictions["ml_g0"][:, :, 0]
     ext_predictions["d"]["ml_g1"] = dml_did.predictions["ml_g1"][:, :, 0]
-    ext_predictions["d"]["ml_m"] = dml_did.predictions["ml_m"][:, :, 0]
+    if did_score == "observational":
+        ext_predictions["d"]["ml_m"] = dml_did.predictions["ml_m"][:, :, 0]
 
     dml_did_ext = DoubleMLDID(ml_g=DMLDummyRegressor(), ml_m=DMLDummyClassifier(), **kwargs)
     dml_did_ext.set_sample_splitting(all_smpls)

--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -54,7 +54,7 @@ class DoubleML(ABC):
         # initialize predictions and target to None which are only stored if method fit is called with store_predictions=True
         self._predictions = None
         self._nuisance_targets = None
-        self._losses = None
+        self._nuisance_loss = None
 
         # initialize models to None which are only stored if method fit is called with store_models=True
         self._models = None
@@ -119,10 +119,10 @@ class DoubleML(ABC):
         learner_info = ''
         for key, value in self.learner.items():
             learner_info += f'Learner {key}: {str(value)}\n'
-        if self.rmses is not None:
+        if self.nuisance_loss is not None:
             learner_info += 'Out-of-sample Performance:\n'
             for learner in self.params_names:
-                learner_info += f'Learner {learner} RMSE: {self.rmses[learner]}\n'
+                learner_info += f'Learner {learner} RMSE: {self.nuisance_loss[learner]}\n'
 
         if self._is_cluster_data:
             resampling_info = f'No. folds per cluster: {self._n_folds_per_cluster}\n' \

--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -122,7 +122,7 @@ class DoubleML(ABC):
         if self.nuisance_loss is not None:
             learner_info += 'Out-of-sample Performance:\n'
             for learner in self.params_names:
-                learner_info += f'Learner {learner} RMSE: {self.nuisance_loss[learner]}\n'
+                learner_info += f'Learner {learner} Loss: {self.nuisance_loss[learner]}\n'
 
         if self._is_cluster_data:
             resampling_info = f'No. folds per cluster: {self._n_folds_per_cluster}\n' \
@@ -915,7 +915,7 @@ class DoubleML(ABC):
             raise NotImplementedError(f"External predictions not implemented for {self.__class__.__name__}.")
 
     def _initalize_fit(self, store_predictions, store_models):
-        # initialize rmse arrays for nuisance functions evaluation
+        # initialize loss arrays for nuisance functions evaluation
         self._initialize_nuisance_loss()
 
         if store_predictions:
@@ -1022,9 +1022,10 @@ class DoubleML(ABC):
             if targets[learner] is None:
                 self._nuisance_loss[learner][self._i_rep, self._i_treat] = np.nan
             else:
-                learner_key = [key for key in self._learner.keys() if key in learner][0]
+                learner_keys = [key for key in self._learner.keys() if key in learner]
+                assert len(learner_keys) == 1
                 is_classifier = self._check_learner(
-                    self._learner[learner_key],
+                    self._learner[learner_keys[0]],
                     learner,
                     regressor=True, classifier=True
                 )

--- a/doubleml/tests/test_evaluate_learner.py
+++ b/doubleml/tests/test_evaluate_learner.py
@@ -49,7 +49,7 @@ def dml_irm_eval_learner_fixture(learner, trimming_threshold, n_rep):
     dml_irm_obj.fit()
     res_manual = dml_irm_obj.evaluate_learners()
 
-    res_dict = {'rmses': dml_irm_obj.rmses,
+    res_dict = {'rmses': dml_irm_obj.nuisance_loss,
                 'rmses_manual': res_manual
                 }
     return res_dict

--- a/doubleml/tests/test_evaluate_learner.py
+++ b/doubleml/tests/test_evaluate_learner.py
@@ -7,6 +7,8 @@ from sklearn.base import clone
 from sklearn.linear_model import LogisticRegression, LinearRegression
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 
+from doubleml.utils._estimation import _logloss
+
 
 np.random.seed(3141)
 data = make_irm_data(theta=0.5, n_obs=200, dim_x=5, return_type='DataFrame')
@@ -47,26 +49,27 @@ def dml_irm_eval_learner_fixture(learner, trimming_threshold, n_rep):
                                   n_rep=n_rep,
                                   trimming_threshold=trimming_threshold)
     dml_irm_obj.fit()
-    res_manual = dml_irm_obj.evaluate_learners()
+    res_manual = dml_irm_obj.evaluate_learners(learners=['ml_g0', 'ml_g1'])
+    res_manual['ml_m'] = dml_irm_obj.evaluate_learners(learners=['ml_m'], metric=_logloss)['ml_m']
 
-    res_dict = {'rmses': dml_irm_obj.nuisance_loss,
-                'rmses_manual': res_manual
+    res_dict = {'nuisance_loss': dml_irm_obj.nuisance_loss,
+                'nuisance_loss_manual': res_manual
                 }
     return res_dict
 
 
 @pytest.mark.ci
 def test_dml_irm_eval_learner(dml_irm_eval_learner_fixture, n_rep):
-    assert dml_irm_eval_learner_fixture['rmses_manual']['ml_g0'].shape == (n_rep, 1)
-    assert dml_irm_eval_learner_fixture['rmses_manual']['ml_g1'].shape == (n_rep, 1)
-    assert dml_irm_eval_learner_fixture['rmses_manual']['ml_m'].shape == (n_rep, 1)
+    assert dml_irm_eval_learner_fixture['nuisance_loss_manual']['ml_g0'].shape == (n_rep, 1)
+    assert dml_irm_eval_learner_fixture['nuisance_loss_manual']['ml_g1'].shape == (n_rep, 1)
+    assert dml_irm_eval_learner_fixture['nuisance_loss_manual']['ml_m'].shape == (n_rep, 1)
 
-    assert np.allclose(dml_irm_eval_learner_fixture['rmses_manual']['ml_g0'],
-                       dml_irm_eval_learner_fixture['rmses']['ml_g0'],
+    assert np.allclose(dml_irm_eval_learner_fixture['nuisance_loss_manual']['ml_g0'],
+                       dml_irm_eval_learner_fixture['nuisance_loss']['ml_g0'],
                        rtol=1e-9, atol=1e-4)
-    assert np.allclose(dml_irm_eval_learner_fixture['rmses_manual']['ml_g1'],
-                       dml_irm_eval_learner_fixture['rmses']['ml_g1'],
+    assert np.allclose(dml_irm_eval_learner_fixture['nuisance_loss_manual']['ml_g1'],
+                       dml_irm_eval_learner_fixture['nuisance_loss']['ml_g1'],
                        rtol=1e-9, atol=1e-4)
-    assert np.allclose(dml_irm_eval_learner_fixture['rmses_manual']['ml_m'],
-                       dml_irm_eval_learner_fixture['rmses']['ml_m'],
+    assert np.allclose(dml_irm_eval_learner_fixture['nuisance_loss_manual']['ml_m'],
+                       dml_irm_eval_learner_fixture['nuisance_loss']['ml_m'],
                        rtol=1e-9, atol=1e-4)

--- a/doubleml/tests/test_return_types.py
+++ b/doubleml/tests/test_return_types.py
@@ -349,50 +349,50 @@ def test_stored_nuisance_targets():
 
 
 @pytest.mark.ci
-def test_rmses():
-    assert plr_obj.rmses['ml_l'].shape == (n_rep, n_treat)
-    assert plr_obj.rmses['ml_m'].shape == (n_rep, n_treat)
+def test_nuisance_loss():
+    assert plr_obj.nuisance_loss['ml_l'].shape == (n_rep, n_treat)
+    assert plr_obj.nuisance_loss['ml_m'].shape == (n_rep, n_treat)
 
-    assert pliv_obj.rmses['ml_l'].shape == (n_rep, n_treat)
-    assert pliv_obj.rmses['ml_m'].shape == (n_rep, n_treat)
-    assert pliv_obj.rmses['ml_r'].shape == (n_rep, n_treat)
+    assert pliv_obj.nuisance_loss['ml_l'].shape == (n_rep, n_treat)
+    assert pliv_obj.nuisance_loss['ml_m'].shape == (n_rep, n_treat)
+    assert pliv_obj.nuisance_loss['ml_r'].shape == (n_rep, n_treat)
 
-    assert irm_obj.rmses['ml_g0'].shape == (n_rep, n_treat)
-    assert irm_obj.rmses['ml_g1'].shape == (n_rep, n_treat)
-    assert irm_obj.rmses['ml_m'].shape == (n_rep, n_treat)
+    assert irm_obj.nuisance_loss['ml_g0'].shape == (n_rep, n_treat)
+    assert irm_obj.nuisance_loss['ml_g1'].shape == (n_rep, n_treat)
+    assert irm_obj.nuisance_loss['ml_m'].shape == (n_rep, n_treat)
 
-    assert iivm_obj.rmses['ml_g0'].shape == (n_rep, n_treat)
-    assert iivm_obj.rmses['ml_g1'].shape == (n_rep, n_treat)
-    assert iivm_obj.rmses['ml_m'].shape == (n_rep, n_treat)
-    assert iivm_obj.rmses['ml_r0'].shape == (n_rep, n_treat)
-    assert iivm_obj.rmses['ml_r1'].shape == (n_rep, n_treat)
+    assert iivm_obj.nuisance_loss['ml_g0'].shape == (n_rep, n_treat)
+    assert iivm_obj.nuisance_loss['ml_g1'].shape == (n_rep, n_treat)
+    assert iivm_obj.nuisance_loss['ml_m'].shape == (n_rep, n_treat)
+    assert iivm_obj.nuisance_loss['ml_r0'].shape == (n_rep, n_treat)
+    assert iivm_obj.nuisance_loss['ml_r1'].shape == (n_rep, n_treat)
 
-    assert cvar_obj.rmses['ml_g'].shape == (n_rep, n_treat)
-    assert cvar_obj.rmses['ml_m'].shape == (n_rep, n_treat)
+    assert cvar_obj.nuisance_loss['ml_g'].shape == (n_rep, n_treat)
+    assert cvar_obj.nuisance_loss['ml_m'].shape == (n_rep, n_treat)
 
-    assert pq_obj.rmses['ml_g'].shape == (n_rep, n_treat)
-    assert pq_obj.rmses['ml_m'].shape == (n_rep, n_treat)
+    assert pq_obj.nuisance_loss['ml_g'].shape == (n_rep, n_treat)
+    assert pq_obj.nuisance_loss['ml_m'].shape == (n_rep, n_treat)
 
-    assert lpq_obj.rmses['ml_g_du_z0'].shape == (n_rep, n_treat)
-    assert lpq_obj.rmses['ml_g_du_z1'].shape == (n_rep, n_treat)
-    assert lpq_obj.rmses['ml_m_z'].shape == (n_rep, n_treat)
-    assert lpq_obj.rmses['ml_m_d_z0'].shape == (n_rep, n_treat)
-    assert lpq_obj.rmses['ml_m_d_z1'].shape == (n_rep, n_treat)
+    assert lpq_obj.nuisance_loss['ml_g_du_z0'].shape == (n_rep, n_treat)
+    assert lpq_obj.nuisance_loss['ml_g_du_z1'].shape == (n_rep, n_treat)
+    assert lpq_obj.nuisance_loss['ml_m_z'].shape == (n_rep, n_treat)
+    assert lpq_obj.nuisance_loss['ml_m_d_z0'].shape == (n_rep, n_treat)
+    assert lpq_obj.nuisance_loss['ml_m_d_z1'].shape == (n_rep, n_treat)
 
-    assert did_obj.rmses['ml_g0'].shape == (n_rep, n_treat)
-    assert did_obj.rmses['ml_g1'].shape == (n_rep, n_treat)
-    assert did_obj.rmses['ml_m'].shape == (n_rep, n_treat)
+    assert did_obj.nuisance_loss['ml_g0'].shape == (n_rep, n_treat)
+    assert did_obj.nuisance_loss['ml_g1'].shape == (n_rep, n_treat)
+    assert did_obj.nuisance_loss['ml_m'].shape == (n_rep, n_treat)
 
-    assert did_cs_obj.rmses['ml_g_d0_t0'].shape == (n_rep, n_treat)
-    assert did_cs_obj.rmses['ml_g_d0_t1'].shape == (n_rep, n_treat)
-    assert did_cs_obj.rmses['ml_g_d1_t0'].shape == (n_rep, n_treat)
-    assert did_cs_obj.rmses['ml_g_d1_t1'].shape == (n_rep, n_treat)
-    assert did_cs_obj.rmses['ml_m'].shape == (n_rep, n_treat)
+    assert did_cs_obj.nuisance_loss['ml_g_d0_t0'].shape == (n_rep, n_treat)
+    assert did_cs_obj.nuisance_loss['ml_g_d0_t1'].shape == (n_rep, n_treat)
+    assert did_cs_obj.nuisance_loss['ml_g_d1_t0'].shape == (n_rep, n_treat)
+    assert did_cs_obj.nuisance_loss['ml_g_d1_t1'].shape == (n_rep, n_treat)
+    assert did_cs_obj.nuisance_loss['ml_m'].shape == (n_rep, n_treat)
 
-    assert ssm_obj.rmses['ml_g_d0'].shape == (n_rep, n_treat)
-    assert ssm_obj.rmses['ml_g_d1'].shape == (n_rep, n_treat)
-    assert ssm_obj.rmses['ml_m'].shape == (n_rep, n_treat)
-    assert ssm_obj.rmses['ml_pi'].shape == (n_rep, n_treat)
+    assert ssm_obj.nuisance_loss['ml_g_d0'].shape == (n_rep, n_treat)
+    assert ssm_obj.nuisance_loss['ml_g_d1'].shape == (n_rep, n_treat)
+    assert ssm_obj.nuisance_loss['ml_m'].shape == (n_rep, n_treat)
+    assert ssm_obj.nuisance_loss['ml_pi'].shape == (n_rep, n_treat)
 
 
 @pytest.mark.ci

--- a/doubleml/utils/_estimation.py
+++ b/doubleml/utils/_estimation.py
@@ -6,7 +6,7 @@ from sklearn.model_selection import cross_val_predict
 from sklearn.base import clone
 from sklearn.preprocessing import LabelEncoder
 from sklearn.model_selection import KFold, GridSearchCV, RandomizedSearchCV
-from sklearn.metrics import root_mean_squared_error
+from sklearn.metrics import root_mean_squared_error, log_loss
 
 from statsmodels.nonparametric.kde import KDEUnivariate
 
@@ -202,6 +202,12 @@ def _rmse(y_true, y_pred):
     subset = np.logical_not(np.isnan(y_true))
     rmse = root_mean_squared_error(y_true[subset], y_pred[subset])
     return rmse
+
+
+def _logloss(y_true, y_pred):
+    subset = np.logical_not(np.isnan(y_true))
+    logloss = log_loss(y_true[subset], y_pred[subset])
+    return logloss
 
 
 def _predict_zero_one_propensity(learner, X):


### PR DESCRIPTION
### Add Log-Loss
To better evaluate the performance of classifiers for e.g. the IRM model, the nuisance_evaluation now automatically uses Log-Loss instead of RMSE.

### Comments
This naming convention changed from `rmses` to `nuisance_loss`.

- [x] The title of the pull request summarizes the changes made.
- [x] The PR contains a detailed description of all changes and additions.
- [x] References to related issues or PRs are added.
- [x] The code passes all (unit) tests.
- [x] Enhancements or new feature are equipped with unit tests.
- [x] The changes adhere to the PEP8 standards.
