### PR TITLE
Add cov_type and kwargs to BLP object

### DIFF
--- a/doubleml/irm/apo.py
+++ b/doubleml/irm/apo.py
@@ -389,7 +389,7 @@ class DoubleMLAPO(LinearScoreMixin, DoubleML):
 
         return
 
-    def capo(self, basis, is_gate=False):
+    def capo(self, basis, is_gate=False, **kwargs):
         """
         Calculate conditional average potential outcomes (CAPO) for a given basis.
 
@@ -398,9 +398,13 @@ class DoubleMLAPO(LinearScoreMixin, DoubleML):
         basis : :class:`pandas.DataFrame`
             The basis for estimating the best linear predictor. Has to have the shape ``(n_obs, d)``,
             where ``n_obs`` is the number of observations and ``d`` is the number of predictors.
+
         is_gate : bool
             Indicates whether the basis is constructed for GATE/GAPOs (dummy-basis).
             Default is ``False``.
+
+        **kwargs: dict
+            Additional keyword arguments to be passed to :meth:`statsmodels.regression.linear_model.OLS.fit` e.g. ``cov_type``.
 
         Returns
         -------
@@ -420,10 +424,10 @@ class DoubleMLAPO(LinearScoreMixin, DoubleML):
         orth_signal = self.psi_elements['psi_b'].reshape(-1)
         # fit the best linear predictor
         model = DoubleMLBLP(orth_signal, basis=basis, is_gate=is_gate)
-        model.fit()
+        model.fit(**kwargs)
         return model
 
-    def gapo(self, groups):
+    def gapo(self, groups, **kwargs):
         """
         Calculate group average potential outcomes (GAPO) for groups.
 
@@ -433,6 +437,9 @@ class DoubleMLAPO(LinearScoreMixin, DoubleML):
             The group indicator for estimating the best linear predictor. Groups should be mutually exclusive.
             Has to be dummy coded with shape ``(n_obs, d)``, where ``n_obs`` is the number of observations
             and ``d`` is the number of groups or ``(n_obs, 1)`` and contain the corresponding groups (as str).
+
+        **kwargs: dict
+            Additional keyword arguments to be passed to :meth:`statsmodels.regression.linear_model.OLS.fit` e.g. ``cov_type``.
 
         Returns
         -------
@@ -453,5 +460,5 @@ class DoubleMLAPO(LinearScoreMixin, DoubleML):
         if any(groups.sum(0) <= 5):
             warnings.warn('At least one group effect is estimated with less than 6 observations.')
 
-        model = self.capo(groups, is_gate=True)
+        model = self.capo(groups, is_gate=True, **kwargs)
         return model

--- a/doubleml/irm/irm.py
+++ b/doubleml/irm/irm.py
@@ -431,7 +431,7 @@ class DoubleMLIRM(LinearScoreMixin, DoubleML):
 
         return res
 
-    def cate(self, basis, is_gate=False):
+    def cate(self, basis, is_gate=False, **kwargs):
         """
         Calculate conditional average treatment effects (CATE) for a given basis.
 
@@ -440,9 +440,13 @@ class DoubleMLIRM(LinearScoreMixin, DoubleML):
         basis : :class:`pandas.DataFrame`
             The basis for estimating the best linear predictor. Has to have the shape ``(n_obs, d)``,
             where ``n_obs`` is the number of observations and ``d`` is the number of predictors.
+
         is_gate : bool
             Indicates whether the basis is constructed for GATEs (dummy-basis).
             Default is ``False``.
+
+        **kwargs: dict
+            Additional keyword arguments to be passed to :meth:`statsmodels.regression.linear_model.OLS.fit` e.g. ``cov_type``.
 
         Returns
         -------
@@ -462,10 +466,10 @@ class DoubleMLIRM(LinearScoreMixin, DoubleML):
         orth_signal = self.psi_elements['psi_b'].reshape(-1)
         # fit the best linear predictor
         model = DoubleMLBLP(orth_signal, basis=basis, is_gate=is_gate)
-        model.fit()
+        model.fit(**kwargs)
         return model
 
-    def gate(self, groups):
+    def gate(self, groups, **kwargs):
         """
         Calculate group average treatment effects (GATE) for groups.
 
@@ -475,6 +479,9 @@ class DoubleMLIRM(LinearScoreMixin, DoubleML):
             The group indicator for estimating the best linear predictor. Groups should be mutually exclusive.
             Has to be dummy coded with shape ``(n_obs, d)``, where ``n_obs`` is the number of observations
             and ``d`` is the number of groups or ``(n_obs, 1)`` and contain the corresponding groups (as str).
+
+        **kwargs: dict
+            Additional keyword arguments to be passed to :meth:`statsmodels.regression.linear_model.OLS.fit` e.g. ``cov_type``.
 
         Returns
         -------
@@ -495,7 +502,7 @@ class DoubleMLIRM(LinearScoreMixin, DoubleML):
         if any(groups.sum(0) <= 5):
             warnings.warn('At least one group effect is estimated with less than 6 observations.')
 
-        model = self.cate(groups, is_gate=True)
+        model = self.cate(groups, is_gate=True, **kwargs)
         return model
 
     def policy_tree(self, features, depth=2, **tree_params):

--- a/doubleml/irm/tests/test_irm.py
+++ b/doubleml/irm/tests/test_irm.py
@@ -187,8 +187,14 @@ def test_dml_irm_sensitivity_rho0(dml_irm_fixture):
                        rtol=1e-9, atol=1e-4)
 
 
+@pytest.fixture(scope='module',
+                params=["nonrobust", "HC0", "HC1", "HC2", "HC3"])
+def cov_type(request):
+    return request.param
+
+
 @pytest.mark.ci
-def test_dml_irm_cate_gate():
+def test_dml_irm_cate_gate(cov_type):
     n = 9
     # collect data
     np.random.seed(42)
@@ -207,7 +213,7 @@ def test_dml_irm_cate_gate():
     dml_irm_obj.fit()
     # create a random basis
     random_basis = pd.DataFrame(np.random.normal(0, 1, size=(n, 5)))
-    cate = dml_irm_obj.cate(random_basis)
+    cate = dml_irm_obj.cate(random_basis, cov_type=cov_type)
     assert isinstance(cate, dml.utils.blp.DoubleMLBLP)
     assert isinstance(cate.confint(), pd.DataFrame)
 
@@ -216,7 +222,7 @@ def test_dml_irm_cate_gate():
                             columns=['Group 1', 'Group 2'])
     msg = ('At least one group effect is estimated with less than 6 observations.')
     with pytest.warns(UserWarning, match=msg):
-        gate_1 = dml_irm_obj.gate(groups_1)
+        gate_1 = dml_irm_obj.gate(groups_1, cov_type=cov_type)
     assert isinstance(gate_1, dml.utils.blp.DoubleMLBLP)
     assert isinstance(gate_1.confint(), pd.DataFrame)
     assert all(gate_1.confint().index == groups_1.columns.to_list())
@@ -225,7 +231,7 @@ def test_dml_irm_cate_gate():
     groups_2 = pd.DataFrame(np.random.choice(["1", "2"], n))
     msg = ('At least one group effect is estimated with less than 6 observations.')
     with pytest.warns(UserWarning, match=msg):
-        gate_2 = dml_irm_obj.gate(groups_2)
+        gate_2 = dml_irm_obj.gate(groups_2, cov_type=cov_type)
     assert isinstance(gate_2, dml.utils.blp.DoubleMLBLP)
     assert isinstance(gate_2.confint(), pd.DataFrame)
     assert all(gate_2.confint().index == ["Group_1", "Group_2"])

--- a/doubleml/irm/tests/test_irm.py
+++ b/doubleml/irm/tests/test_irm.py
@@ -216,6 +216,7 @@ def test_dml_irm_cate_gate(cov_type):
     cate = dml_irm_obj.cate(random_basis, cov_type=cov_type)
     assert isinstance(cate, dml.utils.blp.DoubleMLBLP)
     assert isinstance(cate.confint(), pd.DataFrame)
+    assert cate.blp_model.cov_type == cov_type
 
     groups_1 = pd.DataFrame(np.column_stack([obj_dml_data.data['X1'] <= 0,
                                              obj_dml_data.data['X1'] > 0.2]),
@@ -226,6 +227,7 @@ def test_dml_irm_cate_gate(cov_type):
     assert isinstance(gate_1, dml.utils.blp.DoubleMLBLP)
     assert isinstance(gate_1.confint(), pd.DataFrame)
     assert all(gate_1.confint().index == groups_1.columns.to_list())
+    assert gate_1.blp_model.cov_type == cov_type
 
     np.random.seed(42)
     groups_2 = pd.DataFrame(np.random.choice(["1", "2"], n))
@@ -235,6 +237,7 @@ def test_dml_irm_cate_gate(cov_type):
     assert isinstance(gate_2, dml.utils.blp.DoubleMLBLP)
     assert isinstance(gate_2.confint(), pd.DataFrame)
     assert all(gate_2.confint().index == ["Group_1", "Group_2"])
+    assert gate_2.blp_model.cov_type == cov_type
 
 
 @pytest.fixture(scope='module',

--- a/doubleml/plm/plr.py
+++ b/doubleml/plm/plr.py
@@ -341,7 +341,7 @@ class DoubleMLPLR(LinearScoreMixin, DoubleML):
 
         return res
 
-    def cate(self, basis, is_gate=False):
+    def cate(self, basis, is_gate=False, **kwargs):
         """
         Calculate conditional average treatment effects (CATE) for a given basis.
 
@@ -350,9 +350,13 @@ class DoubleMLPLR(LinearScoreMixin, DoubleML):
         basis : :class:`pandas.DataFrame`
             The basis for estimating the best linear predictor. Has to have the shape ``(n_obs, d)``,
             where ``n_obs`` is the number of observations and ``d`` is the number of predictors.
+
         is_gate : bool
             Indicates whether the basis is constructed for GATEs (dummy-basis).
             Default is ``False``.
+
+        **kwargs: dict
+            Additional keyword arguments to be passed to :meth:`statsmodels.regression.linear_model.OLS.fit` e.g. ``cov_type``.
 
         Returns
         -------
@@ -374,10 +378,10 @@ class DoubleMLPLR(LinearScoreMixin, DoubleML):
             basis=D_basis,
             is_gate=is_gate,
         )
-        model.fit()
+        model.fit(**kwargs)
         return model
 
-    def gate(self, groups):
+    def gate(self, groups, **kwargs):
         """
         Calculate group average treatment effects (GATE) for groups.
 
@@ -387,6 +391,9 @@ class DoubleMLPLR(LinearScoreMixin, DoubleML):
             The group indicator for estimating the best linear predictor. Groups should be mutually exclusive.
             Has to be dummy coded with shape ``(n_obs, d)``, where ``n_obs`` is the number of observations
             and ``d`` is the number of groups or ``(n_obs, 1)`` and contain the corresponding groups (as str).
+
+        **kwargs: dict
+            Additional keyword arguments to be passed to :meth:`statsmodels.regression.linear_model.OLS.fit` e.g. ``cov_type``.
 
         Returns
         -------
@@ -407,7 +414,7 @@ class DoubleMLPLR(LinearScoreMixin, DoubleML):
         if any(groups.sum(0) <= 5):
             warnings.warn('At least one group effect is estimated with less than 6 observations.')
 
-        model = self.cate(groups, is_gate=True)
+        model = self.cate(groups, is_gate=True, **kwargs)
         return model
 
     def _partial_out(self):

--- a/doubleml/plm/tests/test_plr.py
+++ b/doubleml/plm/tests/test_plr.py
@@ -327,6 +327,7 @@ def test_dml_plr_cate_gate(score, cov_type):
     cate = dml_plr_obj.cate(random_basis, cov_type=cov_type)
     assert isinstance(cate, dml.DoubleMLBLP)
     assert isinstance(cate.confint(), pd.DataFrame)
+    assert cate.blp_model.cov_type == cov_type
 
     groups_1 = pd.DataFrame(
         np.column_stack([obj_dml_data.data['X1'] <= 0,
@@ -338,6 +339,7 @@ def test_dml_plr_cate_gate(score, cov_type):
     assert isinstance(gate_1, dml.utils.blp.DoubleMLBLP)
     assert isinstance(gate_1.confint(), pd.DataFrame)
     assert all(gate_1.confint().index == groups_1.columns.tolist())
+    assert gate_1.blp_model.cov_type == cov_type
 
     np.random.seed(42)
     groups_2 = pd.DataFrame(np.random.choice(["1", "2"], n))
@@ -347,3 +349,4 @@ def test_dml_plr_cate_gate(score, cov_type):
     assert isinstance(gate_2, dml.utils.blp.DoubleMLBLP)
     assert isinstance(gate_2.confint(), pd.DataFrame)
     assert all(gate_2.confint().index == ["Group_1", "Group_2"])
+    assert gate_2.blp_model.cov_type == cov_type

--- a/doubleml/utils/blp.py
+++ b/doubleml/utils/blp.py
@@ -110,9 +110,18 @@ class DoubleMLBLP:
                                       columns=col_names)
         return df_summary
 
-    def fit(self):
+    def fit(self, cov_type='HC0', **kwargs):
         """
         Estimate DoubleMLBLP models.
+
+        Parameters
+        ----------
+        cov_type : str
+            The covariance type to be used in the estimation. Default is ``'HC0'``.
+            See :meth:`statsmodels.regression.linear_model.OLS.fit` for more information.
+
+        **kwargs: dict
+            Additional keyword arguments to be passed to :meth:`statsmodels.regression.linear_model.OLS.fit`.
 
         Returns
         -------
@@ -120,8 +129,8 @@ class DoubleMLBLP:
         """
 
         # fit the best-linear-predictor of the orthogonal signal with respect to the grid
-        self._blp_model = sm.OLS(self._orth_signal, self._basis).fit()
-        self._blp_omega = self._blp_model.cov_HC0
+        self._blp_model = sm.OLS(self._orth_signal, self._basis).fit(cov_type=cov_type, **kwargs)
+        self._blp_omega = self._blp_model.cov_params().to_numpy()
 
         return self
 

--- a/doubleml/utils/tests/_utils_blp_manual.py
+++ b/doubleml/utils/tests/_utils_blp_manual.py
@@ -5,8 +5,8 @@ from scipy.stats import norm
 import pandas as pd
 
 
-def fit_blp(orth_signal, basis):
-    blp_model = sm.OLS(orth_signal, basis).fit()
+def fit_blp(orth_signal, basis, cov_type, **kwargs):
+    blp_model = sm.OLS(orth_signal, basis).fit(cov_type=cov_type, **kwargs)
 
     return blp_model
 
@@ -15,7 +15,7 @@ def blp_confint(blp_model, basis, joint=False, level=0.95, n_rep_boot=500):
     alpha = 1 - level
     g_hat = blp_model.predict(basis)
 
-    blp_omega = blp_model.cov_HC0
+    blp_omega = blp_model.cov_params().to_numpy()
 
     blp_se = np.sqrt((basis.dot(blp_omega) * basis).sum(axis=1))
 

--- a/doubleml/utils/tests/test_blp.py
+++ b/doubleml/utils/tests/test_blp.py
@@ -19,8 +19,14 @@ def ci_level(request):
     return request.param
 
 
+@pytest.fixture(scope='module',
+                params=["nonrobust", "HC0", "HC1", "HC2", "HC3"])
+def cov_type(request):
+    return request.param
+
+
 @pytest.fixture(scope='module')
-def dml_blp_fixture(ci_joint, ci_level):
+def dml_blp_fixture(ci_joint, ci_level, cov_type):
     n = 50
     np.random.seed(42)
     random_basis = pd.DataFrame(np.random.normal(0, 1, size=(n, 3)))
@@ -30,7 +36,7 @@ def dml_blp_fixture(ci_joint, ci_level):
 
     blp_obj = copy.copy(blp)
     blp.fit()
-    blp_manual = fit_blp(random_signal, random_basis)
+    blp_manual = fit_blp(random_signal, random_basis, cov_type)
 
     np.random.seed(42)
     ci_1 = blp.confint(random_basis, joint=ci_joint, level=ci_level, n_rep_boot=1000)
@@ -49,7 +55,7 @@ def dml_blp_fixture(ci_joint, ci_level):
                 'values': blp.blp_model.fittedvalues,
                 'values_manual':  blp_manual.fittedvalues,
                 'omega': blp.blp_omega,
-                'omega_manual': blp_manual.cov_HC0,
+                'omega_manual': blp_manual.cov_params().to_numpy(),
                 'basis': blp.basis,
                 'signal': blp.orth_signal,
                 'ci_1': ci_1,

--- a/doubleml/utils/tests/test_blp.py
+++ b/doubleml/utils/tests/test_blp.py
@@ -119,6 +119,23 @@ def test_dml_blp_return_types(dml_blp_fixture):
 
 
 @pytest.mark.ci
+def test_dml_blp_defaults():
+    n = 50
+    np.random.seed(42)
+    random_basis = pd.DataFrame(np.random.normal(0, 1, size=(n, 3)))
+    random_signal = np.random.normal(0, 1, size=(n, ))
+
+    blp = dml.DoubleMLBLP(random_signal, random_basis)
+    blp.fit()
+
+    assert np.allclose(blp.blp_omega,
+                       blp.blp_model.cov_HC0,
+                       rtol=1e-9, atol=1e-4)
+
+    assert blp._is_gate is False
+
+
+@pytest.mark.ci
 def test_doubleml_exception_blp():
     random_basis = pd.DataFrame(np.random.normal(0, 1, size=(2, 3)))
     signal = np.array([1, 2])

--- a/doubleml/utils/tests/test_blp.py
+++ b/doubleml/utils/tests/test_blp.py
@@ -35,7 +35,7 @@ def dml_blp_fixture(ci_joint, ci_level, cov_type):
     blp = dml.DoubleMLBLP(random_signal, random_basis)
 
     blp_obj = copy.copy(blp)
-    blp.fit()
+    blp.fit(cov_type=cov_type)
     blp_manual = fit_blp(random_signal, random_basis, cov_type)
 
     np.random.seed(42)

--- a/doubleml/utils/tests/test_blp.py
+++ b/doubleml/utils/tests/test_blp.py
@@ -25,9 +25,17 @@ def cov_type(request):
     return request.param
 
 
+@pytest.fixture(scope='module',
+                params=[True, False])
+def use_t(request):
+    return request.param
+
+
 @pytest.fixture(scope='module')
-def dml_blp_fixture(ci_joint, ci_level, cov_type):
+def dml_blp_fixture(ci_joint, ci_level, cov_type, use_t):
     n = 50
+    kwargs = {'cov_type': cov_type, 'use_t': use_t}
+
     np.random.seed(42)
     random_basis = pd.DataFrame(np.random.normal(0, 1, size=(n, 3)))
     random_signal = np.random.normal(0, 1, size=(n, ))
@@ -35,8 +43,8 @@ def dml_blp_fixture(ci_joint, ci_level, cov_type):
     blp = dml.DoubleMLBLP(random_signal, random_basis)
 
     blp_obj = copy.copy(blp)
-    blp.fit(cov_type=cov_type)
-    blp_manual = fit_blp(random_signal, random_basis, cov_type)
+    blp.fit(**kwargs)
+    blp_manual = fit_blp(random_signal, random_basis, **kwargs)
 
     np.random.seed(42)
     ci_1 = blp.confint(random_basis, joint=ci_joint, level=ci_level, n_rep_boot=1000)


### PR DESCRIPTION
### Description
The ``DoubleMLBLP.fit()`` object now allows to set ``kwargs`` for the ``OLS.fit()`` method from statsmodels.
Further the default covariance type is set to ``cov_type='HC0'``.

All ``cate`` and ``gate`` method pass ``kwargs`` to ``DoubleMLBLP.fit()`` (and use the same default).

### Reference to Issues or PRs
Implements #270 

### PR Checklist
Please fill out this PR checklist (see our [contributing guidelines](https://github.com/DoubleML/doubleml-for-py/blob/main/CONTRIBUTING.md#checklist-for-pull-requests-pr) for details).

- [ ] The title of the pull request summarizes the changes made.
- [ ] The PR contains a detailed description of all changes and additions.
- [ ] References to related issues or PRs are added.
- [ ] The code passes all (unit) tests.
- [ ] Enhancements or new feature are equipped with unit tests.
- [ ] The changes adhere to the PEP8 standards.
