### PR TITLE
Temporarly fix Scikit-Learn Version to smaller than 1.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ joblib
 numpy
 pandas
 scipy
-scikit-learn
+scikit-learn<1.6.0
 statsmodels
 plotly
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'numpy',
         'pandas',
         'scipy',
-        'scikit-learn',
+        'scikit-learn<1.6.0',
         'statsmodels',
         'plotly',
     ],


### PR DESCRIPTION
### Description
Change setup and requirements to require an older version of sci-kit learn to avoid failing unit tests due to xgboost.

### Reference to Issues or PRs
#278 and https://github.com/dmlc/xgboost/issues/11093

### Comments
XGBoost has a fix on ``main``, we can reverse this as soon as they have a new release.

### PR Checklist

- [x] The title of the pull request summarizes the changes made.
- [x] The PR contains a detailed description of all changes and additions.
- [x] References to related issues or PRs are added.
- [x] The code passes all (unit) tests.
- [x] Enhancements or new feature are equipped with unit tests.
- [x] The changes adhere to the PEP8 standards.
