### PR TITLE
Fix sklearn version requirement to avoid import error.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ joblib
 numpy
 pandas
 scipy
-scikit-learn<1.6.0
+scikit-learn>=1.4.0,<1.6.0
 statsmodels
 plotly
 matplotlib


### PR DESCRIPTION

### Description
DML imports methods from scikit-learn, notably, root_mean_squared_error, which is implemented starting from scikit-learn version 1.4. 
File requirements.txt for DML requires scikit-learn version < 1.6.0 which in some environments installs scikit-learn earlier than 1.4 causing an Import Error.
This PR refines the requirement so that scikit-learn version must be between 1.4.0 (including) and 1.6.0 (excluding).

![sklearn_1 3 0](https://github.com/user-attachments/assets/046addd6-6604-4e18-b990-9f32738130bc)
![sklearn_1 4 0](https://github.com/user-attachments/assets/1e903434-95a6-4fe8-b8e1-723e8e965405)

### Reference to Issues or PRs
#279 

### PR Checklist

- [x] The title of the pull request summarizes the changes made.
- [x] The PR contains a detailed description of all changes and additions.
- [x] References to related issues or PRs are added.
- [x] The code passes all (unit) tests.
- [x] Enhancements or new feature are equipped with unit tests.
- [x] The changes adhere to the PEP8 standards.

