### PR TITLE
Update global learners to work with scikit-learn 1.6.0

### DIFF
--- a/doubleml/irm/tests/test_apos_external_predictions.py
+++ b/doubleml/irm/tests/test_apos_external_predictions.py
@@ -57,7 +57,7 @@ def doubleml_apos_ext_fixture(n_rep, treatment_levels, set_ml_m_ext, set_ml_g_ex
         "draw_sample_splitting": False,
     }
 
-    dml_obj = DoubleMLAPOS(ml_g=LinearRegression(), ml_m=LogisticRegression(), **kwargs)
+    dml_obj = DoubleMLAPOS(ml_g=LinearRegression(), ml_m=LogisticRegression(random_state=42), **kwargs)
     dml_obj.set_sample_splitting(all_smpls=all_smpls)
 
     np.random.seed(3141)

--- a/doubleml/irm/tests/test_ssm_exceptions.py
+++ b/doubleml/irm/tests/test_ssm_exceptions.py
@@ -241,7 +241,7 @@ def test_ssm_exception_learner():
     # construct a classifier which is not identifiable as classifier via is_classifier by sklearn
     # it then predicts labels and therefore an exception will be thrown
     log_reg = LogisticRegressionManipulatedType()
-    # TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0
+    # TODO(0.11) can be removed if the sklearn dependency is bumped to 1.6.0
     log_reg._estimator_type = None
     msg = (
         r"Learner provided for ml_m is probably invalid: LogisticRegressionManipulatedType\(\) is \(probably\) "

--- a/doubleml/irm/tests/test_ssm_exceptions.py
+++ b/doubleml/irm/tests/test_ssm_exceptions.py
@@ -203,6 +203,13 @@ class _DummyNoClassifier(_DummyNoGetParams):
         pass
 
 
+class LogisticRegressionManipulatedType(LogisticRegression):
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.estimator_type = None
+        return tags
+
+
 @pytest.mark.ci
 @pytest.mark.filterwarnings(
     r"ignore:.*is \(probably\) neither a regressor nor a classifier.*:UserWarning",
@@ -233,9 +240,13 @@ def test_ssm_exception_learner():
 
     # construct a classifier which is not identifiable as classifier via is_classifier by sklearn
     # it then predicts labels and therefore an exception will be thrown
-    log_reg = LogisticRegression()
+    log_reg = LogisticRegressionManipulatedType()
+    # TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0
     log_reg._estimator_type = None
-    msg = r"Learner provided for ml_m is probably invalid: LogisticRegression\(\) is \(probably\) no classifier."
+    msg = (
+        r"Learner provided for ml_m is probably invalid: LogisticRegressionManipulatedType\(\) is \(probably\) "
+        "no classifier."
+    )
     with pytest.warns(UserWarning, match=msg):
         _ = DoubleMLSSM(dml_data_mar, ml_g, ml_pi, log_reg)
 

--- a/doubleml/tests/test_exceptions.py
+++ b/doubleml/tests/test_exceptions.py
@@ -1069,7 +1069,7 @@ def test_doubleml_exception_learner():
     # construct a classifier which is not identifiable as classifier via is_classifier by sklearn
     # it then predicts labels and therefore an exception will be thrown
     log_reg = LogisticRegressionManipulatedPredict()
-    # TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0
+    # TODO(0.11) can be removed if the sklearn dependency is bumped to 1.6.0
     log_reg._estimator_type = None
     msg = (
         r"Learner provided for ml_m is probably invalid: LogisticRegressionManipulatedPredict\(\) is \(probably\) "
@@ -1089,7 +1089,7 @@ def test_doubleml_exception_learner():
     # it then predicts labels and therefore an exception will be thrown
     # whether predict() or predict_proba() is being called can also be manipulated via the unrelated max_iter variable
     log_reg = LogisticRegressionManipulatedPredict()
-    # TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0
+    # TODO(0.11) can be removed if the sklearn dependency is bumped to 1.6.0
     log_reg._estimator_type = None
     msg = (
         r"Learner provided for ml_g is probably invalid: LogisticRegressionManipulatedPredict\(\) is \(probably\) "

--- a/doubleml/tests/test_exceptions.py
+++ b/doubleml/tests/test_exceptions.py
@@ -969,6 +969,11 @@ class _DummyNoClassifier(_DummyNoGetParams):
 
 
 class LogisticRegressionManipulatedPredict(LogisticRegression):
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.estimator_type = None
+        return tags
+
     def predict(self, X):
         if self.max_iter == 314:
             preds = super().predict_proba(X)[:, 1]
@@ -1063,16 +1068,17 @@ def test_doubleml_exception_learner():
 
     # construct a classifier which is not identifiable as classifier via is_classifier by sklearn
     # it then predicts labels and therefore an exception will be thrown
-    log_reg = LogisticRegression()
+    log_reg = LogisticRegressionManipulatedPredict()
+    # TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0
     log_reg._estimator_type = None
     msg = (
-        r"Learner provided for ml_m is probably invalid: LogisticRegression\(\) is \(probably\) neither a regressor "
-        "nor a classifier. Method predict is used for prediction."
+        r"Learner provided for ml_m is probably invalid: LogisticRegressionManipulatedPredict\(\) is \(probably\) "
+        "neither a regressor nor a classifier. Method predict is used for prediction."
     )
     with pytest.warns(UserWarning, match=msg):
         dml_plr_hidden_classifier = DoubleMLPLR(dml_data_irm, Lasso(), log_reg)
     msg = (
-        r"For the binary variable d, predictions obtained with the ml_m learner LogisticRegression\(\) "
+        r"For the binary variable d, predictions obtained with the ml_m learner LogisticRegressionManipulatedPredict\(\) "
         "are also observed to be binary with values 0 and 1. Make sure that for classifiers probabilities and not "
         "labels are predicted."
     )
@@ -1083,6 +1089,7 @@ def test_doubleml_exception_learner():
     # it then predicts labels and therefore an exception will be thrown
     # whether predict() or predict_proba() is being called can also be manipulated via the unrelated max_iter variable
     log_reg = LogisticRegressionManipulatedPredict()
+    # TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0
     log_reg._estimator_type = None
     msg = (
         r"Learner provided for ml_g is probably invalid: LogisticRegressionManipulatedPredict\(\) is \(probably\) "

--- a/doubleml/utils/dummy_learners.py
+++ b/doubleml/utils/dummy_learners.py
@@ -1,7 +1,7 @@
-from sklearn.base import BaseEstimator
+from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 
 
-class DMLDummyRegressor(BaseEstimator):
+class DMLDummyRegressor(RegressorMixin, BaseEstimator):
     """
     A dummy regressor that raises an AttributeError when attempting to access
     its fit, predict, or set_params methods.
@@ -35,7 +35,7 @@ class DMLDummyRegressor(BaseEstimator):
         raise AttributeError("Accessed set_params method of DMLDummyRegressor!")
 
 
-class DMLDummyClassifier(BaseEstimator):
+class DMLDummyClassifier(ClassifierMixin, BaseEstimator):
     """
     A dummy classifier that raises an AttributeError when attempting to access
     its fit, predict, set_params, or predict_proba methods.

--- a/doubleml/utils/global_learner.py
+++ b/doubleml/utils/global_learner.py
@@ -1,8 +1,10 @@
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin, clone, is_classifier, is_regressor
 from sklearn.utils.multiclass import unique_labels
 
+from sklearn.utils.validation import validate_data, check_is_fitted, _check_sample_weight
 
-class GlobalRegressor(BaseEstimator, RegressorMixin):
+
+class GlobalRegressor(RegressorMixin, BaseEstimator):
     """
     A global regressor that ignores the attribute `sample_weight` when being fit to ensure a global fit.
 
@@ -13,9 +15,6 @@ class GlobalRegressor(BaseEstimator, RegressorMixin):
     """
 
     def __init__(self, base_estimator):
-        if not is_regressor(base_estimator):
-            raise ValueError(f"base_estimator must be a regressor. Got {base_estimator.__class__.__name__} instead.")
-
         self.base_estimator = base_estimator
 
     def fit(self, X, y, sample_weight=None):
@@ -33,6 +32,11 @@ class GlobalRegressor(BaseEstimator, RegressorMixin):
         sample_weight: array-like of shape (n_samples,).
         Individual weights for each sample. Ignored.
         """
+        if not is_regressor(self.base_estimator):
+            raise ValueError(f"base_estimator must be a regressor. Got {self.base_estimator.__class__.__name__} instead.")
+
+        X, y = validate_data(self, X, y)
+        _check_sample_weight(sample_weight, X)
         self._fitted_learner = clone(self.base_estimator)
         self._fitted_learner.fit(X, y)
 
@@ -47,10 +51,12 @@ class GlobalRegressor(BaseEstimator, RegressorMixin):
         X: array-like of shape (n_samples, n_features)
         Samples.
         """
+
+        check_is_fitted(self)
         return self._fitted_learner.predict(X)
 
 
-class GlobalClassifier(BaseEstimator, ClassifierMixin):
+class GlobalClassifier(ClassifierMixin, BaseEstimator):
     """
     A global classifier that ignores the attribute ``sample_weight`` when being fit to ensure a global fit.
 
@@ -61,9 +67,6 @@ class GlobalClassifier(BaseEstimator, ClassifierMixin):
     """
 
     def __init__(self, base_estimator):
-        if not is_classifier(base_estimator):
-            raise ValueError(f"base_estimator must be a classifier. Got {base_estimator.__class__.__name__} instead.")
-
         self.base_estimator = base_estimator
 
     def fit(self, X, y, sample_weight=None):
@@ -81,6 +84,11 @@ class GlobalClassifier(BaseEstimator, ClassifierMixin):
         sample_weight: array-like of shape (n_samples,).
         Individual weights for each sample. Ignored.
         """
+        if not is_classifier(self.base_estimator):
+            raise ValueError(f"base_estimator must be a classifier. Got {self.base_estimator.__class__.__name__} instead.")
+
+        X, y = validate_data(self, X, y)
+        _check_sample_weight(sample_weight, X)
         self.classes_ = unique_labels(y)
         self._fitted_learner = clone(self.base_estimator)
         self._fitted_learner.fit(X, y)
@@ -96,6 +104,7 @@ class GlobalClassifier(BaseEstimator, ClassifierMixin):
         X: array-like of shape (n_samples, n_features)
         Samples.
         """
+        check_is_fitted(self)
         return self._fitted_learner.predict(X)
 
     def predict_proba(self, X):
@@ -108,4 +117,5 @@ class GlobalClassifier(BaseEstimator, ClassifierMixin):
         X: array-like of shape (n_samples, n_features)
         Samples to be scored.
         """
+        check_is_fitted(self)
         return self._fitted_learner.predict_proba(X)

--- a/doubleml/utils/global_learner.py
+++ b/doubleml/utils/global_learner.py
@@ -5,7 +5,7 @@ from sklearn.utils.validation import _check_sample_weight, check_is_fitted
 
 
 def parse_version(version):
-    return tuple(map(int, version.split('.')[:2]))
+    return tuple(map(int, version.split(".")[:2]))
 
 
 # TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0

--- a/doubleml/utils/global_learner.py
+++ b/doubleml/utils/global_learner.py
@@ -8,7 +8,7 @@ def parse_version(version):
     return tuple(map(int, version.split(".")[:2]))
 
 
-# TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0
+# TODO(0.11) can be removed if the sklearn dependency is bumped to 1.6.0
 sklearn_supports_validation = parse_version(sklearn_version) >= (1, 6)
 if sklearn_supports_validation:
     from sklearn.utils.validation import validate_data
@@ -45,7 +45,7 @@ class GlobalRegressor(RegressorMixin, BaseEstimator):
         if not is_regressor(self.base_estimator):
             raise ValueError(f"base_estimator must be a regressor. Got {self.base_estimator.__class__.__name__} instead.")
 
-        # TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0
+        # TODO(0.11) can be removed if the sklearn dependency is bumped to 1.6.0
         if sklearn_supports_validation:
             X, y = validate_data(self, X, y)
         else:
@@ -101,7 +101,7 @@ class GlobalClassifier(ClassifierMixin, BaseEstimator):
         if not is_classifier(self.base_estimator):
             raise ValueError(f"base_estimator must be a classifier. Got {self.base_estimator.__class__.__name__} instead.")
 
-        # TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0
+        # TODO(0.11) can be removed if the sklearn dependency is bumped to 1.6.0
         if sklearn_supports_validation:
             X, y = validate_data(self, X, y)
         else:

--- a/doubleml/utils/global_learner.py
+++ b/doubleml/utils/global_learner.py
@@ -1,6 +1,14 @@
+from distutils.version import LooseVersion
+
+from sklearn import __version__ as sklearn_version
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin, clone, is_classifier, is_regressor
 from sklearn.utils.multiclass import unique_labels
-from sklearn.utils.validation import _check_sample_weight, check_is_fitted, validate_data
+from sklearn.utils.validation import _check_sample_weight, check_is_fitted
+
+# TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0
+sklearn_supports_validation = LooseVersion(sklearn_version) >= LooseVersion("1.6")
+if sklearn_supports_validation:
+    from sklearn.utils.validation import validate_data
 
 
 class GlobalRegressor(RegressorMixin, BaseEstimator):
@@ -34,7 +42,11 @@ class GlobalRegressor(RegressorMixin, BaseEstimator):
         if not is_regressor(self.base_estimator):
             raise ValueError(f"base_estimator must be a regressor. Got {self.base_estimator.__class__.__name__} instead.")
 
-        X, y = validate_data(self, X, y)
+        # TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0
+        if sklearn_supports_validation:
+            X, y = validate_data(self, X, y)
+        else:
+            X, y = self._validate_data(X, y)
         _check_sample_weight(sample_weight, X)
         self._fitted_learner = clone(self.base_estimator)
         self._fitted_learner.fit(X, y)
@@ -86,7 +98,11 @@ class GlobalClassifier(ClassifierMixin, BaseEstimator):
         if not is_classifier(self.base_estimator):
             raise ValueError(f"base_estimator must be a classifier. Got {self.base_estimator.__class__.__name__} instead.")
 
-        X, y = validate_data(self, X, y)
+        # TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0
+        if sklearn_supports_validation:
+            X, y = validate_data(self, X, y)
+        else:
+            X, y = self._validate_data(X, y)
         _check_sample_weight(sample_weight, X)
         self.classes_ = unique_labels(y)
         self._fitted_learner = clone(self.base_estimator)

--- a/doubleml/utils/global_learner.py
+++ b/doubleml/utils/global_learner.py
@@ -1,7 +1,6 @@
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin, clone, is_classifier, is_regressor
 from sklearn.utils.multiclass import unique_labels
-
-from sklearn.utils.validation import validate_data, check_is_fitted, _check_sample_weight
+from sklearn.utils.validation import _check_sample_weight, check_is_fitted, validate_data
 
 
 class GlobalRegressor(RegressorMixin, BaseEstimator):

--- a/doubleml/utils/global_learner.py
+++ b/doubleml/utils/global_learner.py
@@ -1,12 +1,15 @@
-from distutils.version import LooseVersion
-
 from sklearn import __version__ as sklearn_version
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin, clone, is_classifier, is_regressor
 from sklearn.utils.multiclass import unique_labels
 from sklearn.utils.validation import _check_sample_weight, check_is_fitted
 
+
+def parse_version(version):
+    return tuple(map(int, version.split('.')[:2]))
+
+
 # TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0
-sklearn_supports_validation = LooseVersion(sklearn_version) >= LooseVersion("1.6")
+sklearn_supports_validation = parse_version(sklearn_version) >= (1, 6)
 if sklearn_supports_validation:
     from sklearn.utils.validation import validate_data
 

--- a/doubleml/utils/tests/test_exceptions_global_learners.py
+++ b/doubleml/utils/tests/test_exceptions_global_learners.py
@@ -8,11 +8,13 @@ from doubleml.utils import GlobalClassifier, GlobalRegressor
 def test_global_regressor_input():
     msg = "base_estimator must be a regressor. Got LogisticRegression instead."
     with pytest.raises(ValueError, match=msg):
-        _ = GlobalRegressor(base_estimator=LogisticRegression(random_state=42))
+        reg = GlobalRegressor(base_estimator=LogisticRegression(random_state=42))
+        reg.fit(X=[[1, 2], [3, 4]], y=[1, 2])
 
 
 @pytest.mark.ci
 def test_global_classifier_input():
     msg = "base_estimator must be a classifier. Got LinearRegression instead."
     with pytest.raises(ValueError, match=msg):
-        _ = GlobalClassifier(base_estimator=LinearRegression())
+        clas = GlobalClassifier(base_estimator=LinearRegression())
+        clas.fit(X=[[1, 2], [3, 4]], y=[1, 2])

--- a/doubleml/utils/tests/test_global_learners.py
+++ b/doubleml/utils/tests/test_global_learners.py
@@ -1,5 +1,3 @@
-from distutils.version import LooseVersion
-
 import numpy as np
 import pytest
 from sklearn import __version__ as sklearn_version
@@ -11,8 +9,13 @@ from sklearn.utils.estimator_checks import check_estimator
 
 from doubleml.utils import GlobalClassifier, GlobalRegressor
 
+
+def parse_version(version):
+    return tuple(map(int, version.split('.')[:2]))
+
+
 # TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0
-sklearn_post_1_6 = LooseVersion(sklearn_version) >= LooseVersion("1.6")
+sklearn_post_1_6 = parse_version(sklearn_version) >= (1, 6)
 
 
 @pytest.fixture(

--- a/doubleml/utils/tests/test_global_learners.py
+++ b/doubleml/utils/tests/test_global_learners.py
@@ -14,7 +14,7 @@ def parse_version(version):
     return tuple(map(int, version.split(".")[:2]))
 
 
-# TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0
+# TODO(0.11) can be removed if the sklearn dependency is bumped to 1.6.0
 sklearn_post_1_6 = parse_version(sklearn_version) >= (1, 6)
 
 
@@ -44,7 +44,7 @@ def test_global_regressor(regressor):
             },
         )
     else:
-        # TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0
+        # TODO(0.11) can be removed if the sklearn dependency is bumped to 1.6.0
         pytest.skip("sklearn version is too old for this test")
 
 
@@ -59,7 +59,7 @@ def test_global_classifier(classifier):
             },
         )
     else:
-        # TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0
+        # TODO(0.11) can be removed if the sklearn dependency is bumped to 1.6.0
         pytest.skip("sklearn version is too old for this test")
 
 

--- a/doubleml/utils/tests/test_global_learners.py
+++ b/doubleml/utils/tests/test_global_learners.py
@@ -4,6 +4,7 @@ from sklearn.base import clone
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor, StackingClassifier, StackingRegressor
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.model_selection import KFold
+from sklearn.utils.estimator_checks import check_estimator
 
 from doubleml.utils import GlobalClassifier, GlobalRegressor
 
@@ -21,6 +22,28 @@ def regressor(request):
 )
 def classifier(request):
     return request.param
+
+
+@pytest.mark.ci
+def test_global_regressor(regressor):
+    check_estimator(
+        estimator=GlobalRegressor(base_estimator=regressor),
+        expected_failed_checks={
+            "check_sample_weight_equivalence_on_dense_data": "weights are ignored",
+            "check_estimators_nan_inf": "allowed for some estimators"
+        }
+    )
+
+
+@pytest.mark.ci
+def test_global_classifier(classifier):
+    check_estimator(
+        estimator=GlobalClassifier(base_estimator=classifier),
+        expected_failed_checks={
+            "check_sample_weight_equivalence_on_dense_data": "weights are ignored",
+            "check_estimators_nan_inf": "allowed for some estimators"
+        }
+    )
 
 
 @pytest.fixture(scope="module")

--- a/doubleml/utils/tests/test_global_learners.py
+++ b/doubleml/utils/tests/test_global_learners.py
@@ -11,7 +11,7 @@ from doubleml.utils import GlobalClassifier, GlobalRegressor
 
 
 def parse_version(version):
-    return tuple(map(int, version.split('.')[:2]))
+    return tuple(map(int, version.split(".")[:2]))
 
 
 # TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0

--- a/doubleml/utils/tests/test_global_learners.py
+++ b/doubleml/utils/tests/test_global_learners.py
@@ -1,5 +1,8 @@
+from distutils.version import LooseVersion
+
 import numpy as np
 import pytest
+from sklearn import __version__ as sklearn_version
 from sklearn.base import clone
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor, StackingClassifier, StackingRegressor
 from sklearn.linear_model import LinearRegression, LogisticRegression
@@ -7,6 +10,9 @@ from sklearn.model_selection import KFold
 from sklearn.utils.estimator_checks import check_estimator
 
 from doubleml.utils import GlobalClassifier, GlobalRegressor
+
+# TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0
+sklearn_post_1_6 = LooseVersion(sklearn_version) >= LooseVersion("1.6")
 
 
 @pytest.fixture(
@@ -26,24 +32,32 @@ def classifier(request):
 
 @pytest.mark.ci
 def test_global_regressor(regressor):
-    check_estimator(
-        estimator=GlobalRegressor(base_estimator=regressor),
-        expected_failed_checks={
-            "check_sample_weight_equivalence_on_dense_data": "weights are ignored",
-            "check_estimators_nan_inf": "allowed for some estimators",
-        },
-    )
+    if sklearn_post_1_6:
+        check_estimator(
+            estimator=GlobalRegressor(base_estimator=regressor),
+            expected_failed_checks={
+                "check_sample_weight_equivalence_on_dense_data": "weights are ignored",
+                "check_estimators_nan_inf": "allowed for some estimators",
+            },
+        )
+    else:
+        # TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0
+        pytest.skip("sklearn version is too old for this test")
 
 
 @pytest.mark.ci
 def test_global_classifier(classifier):
-    check_estimator(
-        estimator=GlobalClassifier(base_estimator=classifier),
-        expected_failed_checks={
-            "check_sample_weight_equivalence_on_dense_data": "weights are ignored",
-            "check_estimators_nan_inf": "allowed for some estimators",
-        },
-    )
+    if sklearn_post_1_6:
+        check_estimator(
+            estimator=GlobalClassifier(base_estimator=classifier),
+            expected_failed_checks={
+                "check_sample_weight_equivalence_on_dense_data": "weights are ignored",
+                "check_estimators_nan_inf": "allowed for some estimators",
+            },
+        )
+    else:
+        # TODO(0.10) can be removed if the sklearn dependency is bumped to 1.6.0
+        pytest.skip("sklearn version is too old for this test")
 
 
 @pytest.fixture(scope="module")

--- a/doubleml/utils/tests/test_global_learners.py
+++ b/doubleml/utils/tests/test_global_learners.py
@@ -30,8 +30,8 @@ def test_global_regressor(regressor):
         estimator=GlobalRegressor(base_estimator=regressor),
         expected_failed_checks={
             "check_sample_weight_equivalence_on_dense_data": "weights are ignored",
-            "check_estimators_nan_inf": "allowed for some estimators"
-        }
+            "check_estimators_nan_inf": "allowed for some estimators",
+        },
     )
 
 
@@ -41,8 +41,8 @@ def test_global_classifier(classifier):
         estimator=GlobalClassifier(base_estimator=classifier),
         expected_failed_checks={
             "check_sample_weight_equivalence_on_dense_data": "weights are ignored",
-            "check_estimators_nan_inf": "allowed for some estimators"
-        }
+            "check_estimators_nan_inf": "allowed for some estimators",
+        },
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "numpy",
     "pandas",
     "scipy",
-    "scikit-learn>=1.4.0,<1.6.0",
+    "scikit-learn>=1.4.0",
     "statsmodels",
     "matplotlib",
     "plotly"


### PR DESCRIPTION
- Remove `scikit-learn<1.6.0` restriction (see #290 )
- Update data checks for global estimators
- Add unit test for stacked global learners

### PR Checklist
Please fill out this PR checklist (see our [contributing guidelines](https://github.com/DoubleML/doubleml-for-py/blob/main/CONTRIBUTING.md#checklist-for-pull-requests-pr) for details).

- [x] The title of the pull request summarizes the changes made.
- [x] The PR contains a detailed description of all changes and additions.
- [x] References to related issues or PRs are added.
- [x] The code passes all (unit) tests.
- [x] Enhancements or new feature are equipped with unit tests.
- [x] The changes adhere to the PEP8 standards.
