### PR TITLE
Fix build workflow; convert black error to warning

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -52,7 +52,8 @@ jobs:
         ruff check . --exit-zero --line-length 127 --output-format=full --statistics
     - name: Check code formatting with black
       run: |
-        black --check .
+        black --check --verbose . || echo "Warning: Code is not formatted according to black"
+        exit 0
     - name: Test with pytest
       if: |
         matrix.config.os != 'ubuntu-latest' ||


### PR DESCRIPTION
Just throw a warning if black check fails