### PR TITLE
Update Sensitivity Operations

### DIFF
--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -1429,6 +1429,10 @@ class DoubleML(ABC):
         return sensitivity_elements
 
     def _compute_sensitivity_bias(self, sigma2, nu2, psi_sigma2, psi_nu2, riesz_rep=None):
+        if nu2 <= 0:
+            warnings.UserWarning("The estimated nu2 is not positive. Re-estimation based on riesz representer.")
+            nu2 = np.mean(np.power(riesz_rep, 2))
+
         bias = np.sqrt(np.multiply(sigma2, nu2))
         psi_bias = np.divide(
             np.add(np.multiply(sigma2, psi_nu2), np.multiply(nu2, psi_sigma2)),

--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -565,6 +565,8 @@ class DoubleML(ABC):
                         "psi_sigma2": np.transpose(self.sensitivity_elements["psi_sigma2"], (0, 2, 1)),
                         "psi_nu2": np.transpose(self.sensitivity_elements["psi_nu2"], (0, 2, 1)),
                         "riesz_rep": np.transpose(self.sensitivity_elements["riesz_rep"], (0, 2, 1)),
+                        "bias": np.transpose(self.sensitivity_elements["bias"], (0, 2, 1)),
+                        "psi_bias": np.transpose(self.sensitivity_elements["psi_bias"], (0, 2, 1)),
                     }
                 }
             )

--- a/doubleml/double_ml.py
+++ b/doubleml/double_ml.py
@@ -1430,8 +1430,9 @@ class DoubleML(ABC):
 
     def _compute_sensitivity_bias(self, sigma2, nu2, psi_sigma2, psi_nu2, riesz_rep):
         if nu2 <= 0:
-            warnings.UserWarning(
-                "The estimated nu2 is not positive. Re-estimation based on riesz representer (non-orthogonal)."
+            warnings.warn(
+                "The estimated nu2 is not positive. Re-estimation based on riesz representer (non-orthogonal).",
+                UserWarning,
             )
             psi_nu2 = np.power(riesz_rep, 2)
             nu2 = np.mean(psi_nu2)

--- a/doubleml/double_ml_framework.py
+++ b/doubleml/double_ml_framework.py
@@ -983,7 +983,7 @@ class DoubleMLFramework:
         else:
             if not isinstance(doubleml_dict["sensitivity_elements"], dict):
                 raise TypeError("sensitivity_elements must be a dictionary.")
-            expected_keys_sensitivity = ["sigma2", "nu2", "psi_sigma2", "psi_nu2", "riesz_rep"]
+            expected_keys_sensitivity = ["sigma2", "nu2", "psi_sigma2", "psi_nu2", "riesz_rep", "bias", "psi_bias"]
             if not all(key in doubleml_dict["sensitivity_elements"].keys() for key in expected_keys_sensitivity):
                 raise ValueError(
                     "The sensitivity_elements dict must contain the following keys: " + ", ".join(expected_keys_sensitivity)
@@ -1001,6 +1001,8 @@ class DoubleMLFramework:
                 "psi_sigma2": doubleml_dict["sensitivity_elements"]["psi_sigma2"],
                 "psi_nu2": doubleml_dict["sensitivity_elements"]["psi_nu2"],
                 "riesz_rep": doubleml_dict["sensitivity_elements"]["riesz_rep"],
+                "bias": doubleml_dict["sensitivity_elements"]["bias"],
+                "psi_bias": doubleml_dict["sensitivity_elements"]["psi_bias"],
             }
 
         self._sensitivity_implemented = sensitivity_implemented

--- a/doubleml/double_ml_framework.py
+++ b/doubleml/double_ml_framework.py
@@ -322,7 +322,6 @@ class DoubleMLFramework:
                 "cluster_dict": self._cluster_dict,
             }
 
-            # sensitivity combination only available for same outcome and cond. expectation (e.g. IRM)
             if self._sensitivity_implemented and other._sensitivity_implemented:
                 nu2_score_element = (
                     self._sensitivity_elements["psi_nu2"]
@@ -334,12 +333,16 @@ class DoubleMLFramework:
                 nu2 = np.mean(nu2_score_element, axis=0, keepdims=True)
                 psi_nu2 = nu2_score_element - nu2
 
+                max_bias = self._sensitivity_elements["max_bias"] + other._sensitivity_elements["max_bias"]
+                psi_max_bias = self._sensitivity_elements["psi_max_bias"] + other._sensitivity_elements["psi_max_bias"]
                 sensitivity_elements = {
                     "sigma2": self._sensitivity_elements["sigma2"],
                     "nu2": nu2,
                     "psi_sigma2": self._sensitivity_elements["psi_sigma2"],
                     "psi_nu2": psi_nu2,
                     "riesz_rep": self._sensitivity_elements["riesz_rep"] + other._sensitivity_elements["riesz_rep"],
+                    "max_bias": max_bias,
+                    "psi_max_bias": psi_max_bias,
                 }
                 doubleml_dict["sensitivity_elements"] = sensitivity_elements
 
@@ -394,12 +397,16 @@ class DoubleMLFramework:
                 nu2 = np.mean(nu2_score_element, axis=0, keepdims=True)
                 psi_nu2 = nu2_score_element - nu2
 
+                max_bias = self._sensitivity_elements["max_bias"] + other._sensitivity_elements["max_bias"]
+                psi_max_bias = self._sensitivity_elements["psi_max_bias"] - other._sensitivity_elements["psi_max_bias"]
                 sensitivity_elements = {
                     "sigma2": self._sensitivity_elements["sigma2"],
                     "nu2": nu2,
                     "psi_sigma2": self._sensitivity_elements["psi_sigma2"],
                     "psi_nu2": psi_nu2,
                     "riesz_rep": self._sensitivity_elements["riesz_rep"] - other._sensitivity_elements["riesz_rep"],
+                    "max_bias": max_bias,
+                    "psi_max_bias": psi_max_bias,
                 }
                 doubleml_dict["sensitivity_elements"] = sensitivity_elements
 
@@ -440,12 +447,16 @@ class DoubleMLFramework:
                 nu2 = np.mean(nu2_score_element, axis=0, keepdims=True)
                 psi_nu2 = nu2_score_element - nu2
 
+                max_bias = abs(other) * self._sensitivity_elements["max_bias"]
+                psi_max_bias = abs(other) * self._sensitivity_elements["psi_max_bias"]
                 sensitivity_elements = {
                     "sigma2": self._sensitivity_elements["sigma2"],
                     "nu2": nu2,
                     "psi_sigma2": self._sensitivity_elements["psi_sigma2"],
                     "psi_nu2": psi_nu2,
                     "riesz_rep": np.multiply(other, self._sensitivity_elements["riesz_rep"]),
+                    "max_bias": max_bias,
+                    "psi_max_bias": psi_max_bias,
                 }
                 doubleml_dict["sensitivity_elements"] = sensitivity_elements
 
@@ -1119,7 +1130,7 @@ def concat(objs):
 
     if all(obj._sensitivity_implemented for obj in objs):
         sensitivity_elements = {}
-        for key in ["sigma2", "nu2", "psi_sigma2", "psi_nu2", "riesz_rep"]:
+        for key in ["sigma2", "nu2", "psi_sigma2", "psi_nu2", "riesz_rep", "max_bias", "psi_max_bias"]:
             assert all(key in obj._sensitivity_elements.keys() for obj in objs)
             sensitivity_elements[key] = np.concatenate([obj._sensitivity_elements[key] for obj in objs], axis=1)
 

--- a/doubleml/double_ml_framework.py
+++ b/doubleml/double_ml_framework.py
@@ -473,8 +473,6 @@ class DoubleMLFramework:
         # set elements for readability
         sigma2 = self.sensitivity_elements["sigma2"]
         nu2 = self.sensitivity_elements["nu2"]
-        psi_sigma = self.sensitivity_elements["psi_sigma2"]
-        psi_nu = self.sensitivity_elements["psi_nu2"]
         psi_scaled = self._scaled_psi
         max_bias = self.sensitivity_elements["max_bias"]
         psi_max_bias = self.sensitivity_elements["psi_max_bias"]
@@ -488,16 +486,13 @@ class DoubleMLFramework:
 
         # elementwise operations
         confounding_strength = np.multiply(np.abs(rho), np.sqrt(np.multiply(cf_y, np.divide(cf_d, 1.0 - cf_d))))
-        sensitivity_scaling = np.sqrt(np.multiply(sigma2, nu2))
 
-        # sigma2 and nu2 are of shape (1, n_thetas, n_rep), whereas the all_thetas is of shape (n_thetas, n_rep)
-        all_theta_lower = self.all_thetas - np.multiply(np.squeeze(sensitivity_scaling, axis=0), confounding_strength)
-        all_theta_upper = self.all_thetas + np.multiply(np.squeeze(sensitivity_scaling, axis=0), confounding_strength)
+        # max_bias is of shape (1, n_thetas, n_rep), whereas the all_thetas is of shape (n_thetas, n_rep)
+        all_theta_lower = self.all_thetas - np.multiply(np.squeeze(max_bias, axis=0), confounding_strength)
+        all_theta_upper = self.all_thetas + np.multiply(np.squeeze(max_bias, axis=0), confounding_strength)
 
-        psi_variances = np.multiply(sigma2, psi_nu) + np.multiply(nu2, psi_sigma)
-        psi_bias = np.multiply(np.divide(confounding_strength, np.multiply(2.0, sensitivity_scaling)), psi_variances)
-        psi_lower = psi_scaled - psi_bias
-        psi_upper = psi_scaled + psi_bias
+        psi_lower = psi_scaled - psi_max_bias
+        psi_upper = psi_scaled + psi_max_bias
 
         # shape (n_thetas, n_reps); includes scaling with n^{-1/2}
         all_sigma_lower = np.full_like(all_theta_lower, fill_value=np.nan)

--- a/doubleml/double_ml_framework.py
+++ b/doubleml/double_ml_framework.py
@@ -488,11 +488,11 @@ class DoubleMLFramework:
         confounding_strength = np.multiply(np.abs(rho), np.sqrt(np.multiply(cf_y, np.divide(cf_d, 1.0 - cf_d))))
 
         # max_bias is of shape (1, n_thetas, n_rep), whereas the all_thetas is of shape (n_thetas, n_rep)
-        all_theta_lower = self.all_thetas - np.multiply(np.squeeze(max_bias, axis=0), confounding_strength)
-        all_theta_upper = self.all_thetas + np.multiply(np.squeeze(max_bias, axis=0), confounding_strength)
+        all_theta_lower = self.all_thetas - np.multiply(confounding_strength, np.squeeze(max_bias, axis=0))
+        all_theta_upper = self.all_thetas + np.multiply(confounding_strength, np.squeeze(max_bias, axis=0))
 
-        psi_lower = psi_scaled - psi_max_bias
-        psi_upper = psi_scaled + psi_max_bias
+        psi_lower = psi_scaled - np.multiply(confounding_strength, psi_max_bias)
+        psi_upper = psi_scaled + np.multiply(confounding_strength, psi_max_bias)
 
         # shape (n_thetas, n_reps); includes scaling with n^{-1/2}
         all_sigma_lower = np.full_like(all_theta_lower, fill_value=np.nan)

--- a/doubleml/double_ml_framework.py
+++ b/doubleml/double_ml_framework.py
@@ -476,6 +476,8 @@ class DoubleMLFramework:
         psi_sigma = self.sensitivity_elements["psi_sigma2"]
         psi_nu = self.sensitivity_elements["psi_nu2"]
         psi_scaled = self._scaled_psi
+        max_bias = self.sensitivity_elements["max_bias"]
+        psi_max_bias = self.sensitivity_elements["psi_max_bias"]
 
         if (np.any(sigma2 < 0)) | (np.any(nu2 < 0)):
             raise ValueError(
@@ -983,7 +985,7 @@ class DoubleMLFramework:
         else:
             if not isinstance(doubleml_dict["sensitivity_elements"], dict):
                 raise TypeError("sensitivity_elements must be a dictionary.")
-            expected_keys_sensitivity = ["sigma2", "nu2", "psi_sigma2", "psi_nu2", "riesz_rep", "bias", "psi_bias"]
+            expected_keys_sensitivity = ["sigma2", "nu2", "psi_sigma2", "psi_nu2", "riesz_rep", "max_bias", "psi_max_bias"]
             if not all(key in doubleml_dict["sensitivity_elements"].keys() for key in expected_keys_sensitivity):
                 raise ValueError(
                     "The sensitivity_elements dict must contain the following keys: " + ", ".join(expected_keys_sensitivity)
@@ -1001,8 +1003,8 @@ class DoubleMLFramework:
                 "psi_sigma2": doubleml_dict["sensitivity_elements"]["psi_sigma2"],
                 "psi_nu2": doubleml_dict["sensitivity_elements"]["psi_nu2"],
                 "riesz_rep": doubleml_dict["sensitivity_elements"]["riesz_rep"],
-                "bias": doubleml_dict["sensitivity_elements"]["bias"],
-                "psi_bias": doubleml_dict["sensitivity_elements"]["psi_bias"],
+                "max_bias": doubleml_dict["sensitivity_elements"]["max_bias"],
+                "psi_max_bias": doubleml_dict["sensitivity_elements"]["psi_max_bias"],
             }
 
         self._sensitivity_implemented = sensitivity_implemented

--- a/doubleml/tests/test_exceptions.py
+++ b/doubleml/tests/test_exceptions.py
@@ -1229,7 +1229,15 @@ def test_doubleml_sensitivity_inputs():
         _ = dml_irm._set_sensitivity_elements(sensitivity_elements=sensitivity_elements, i_rep=0, i_treat=0)
 
     # test variances
-    sensitivity_elements = dict({"sigma2": 1.0, "nu2": -2.4, "psi_sigma2": 1.0, "psi_nu2": 1.0, "riesz_rep": 1.0})
+    sensitivity_elements = {
+        "sigma2": 1.0,
+        "nu2": -2.4,
+        "psi_sigma2": 1.0,
+        "psi_nu2": 1.0,
+        "riesz_rep": 1.0,
+        "max_bias": 1.0,
+        "psi_max_bias": 1.0,
+    }
     _ = dml_irm._set_sensitivity_elements(sensitivity_elements=sensitivity_elements, i_rep=0, i_treat=0)
     msg = (
         "sensitivity_elements sigma2 and nu2 have to be positive. "

--- a/doubleml/tests/test_framework_exceptions.py
+++ b/doubleml/tests/test_framework_exceptions.py
@@ -22,6 +22,8 @@ doubleml_dict["sensitivity_elements"] = {
     "psi_sigma2": np.ones(shape=(n_obs, n_thetas, n_rep)),
     "psi_nu2": np.ones(shape=(n_obs, n_thetas, n_rep)),
     "riesz_rep": np.ones(shape=(n_obs, n_thetas, n_rep)),
+    "max_bias": np.ones(shape=(1, n_thetas, n_rep)),
+    "psi_max_bias": np.ones(shape=(n_obs, n_thetas, n_rep)),
 }
 
 # combine objects and estimate parameters
@@ -394,6 +396,8 @@ def test_sensitivity_exceptions():
         "psi_sigma2": np.ones(shape=(n_obs, n_thetas, n_rep)),
         "psi_nu2": np.ones(shape=(n_obs, n_thetas, n_rep)),
         "riesz_rep": np.ones(shape=(n_obs, n_thetas, n_rep)),
+        "max_bias": np.ones(shape=(1, n_thetas, n_rep)),
+        "psi_max_bias": np.ones(shape=(n_obs, n_thetas, n_rep)),
     }
     dml_framework_sensitivity = DoubleMLFramework(sensitivity_dict)
 


### PR DESCRIPTION
## Update Sensitivity Operations

Update the sensitivity calculations in the `DoubleMLFramework`:
 - Remove `sigma2`, `nu2`, `psi_sigma2` and `psi_nu2` from `sensitivity_elements` (still contained in `DoubleML`)
 - Add `max_bias` and `psi_max_bias` to `sensitivity_elements`
 - Update operations `+`, `-` and `*`


### PR Checklist

- [x] The title of the pull request summarizes the changes made.
- [ ] The PR contains a detailed description of all changes and additions.
- [ ] References to related issues or PRs are added.
- [ ] The code passes all (unit) tests.
- [ ] Enhancements or new feature are equipped with unit tests.
- [ ] The changes adhere to the PEP8 standards.
