### PR TITLE
Add possibility of user defined bandwidth in rdrobust

### DIFF
--- a/doubleml/rdd/rdd.py
+++ b/doubleml/rdd/rdd.py
@@ -453,10 +453,10 @@ class RDFlex:
     def _fit_rdd(self, h=None, b=None):
         if self.fuzzy:
             rdd_res = rdrobust.rdrobust(
-                y=self._M_Y[:, self._i_rep], x=self._score, fuzzy=self._M_D[:, self._i_rep], h=h, b=b, **self.kwargs
+                y=self._M_Y[:, self._i_rep], x=self._score, fuzzy=self._M_D[:, self._i_rep], h=h, b=b, c=0, **self.kwargs
             )
         else:
-            rdd_res = rdrobust.rdrobust(y=self._M_Y[:, self._i_rep], x=self._score, h=h, b=b, **self.kwargs)
+            rdd_res = rdrobust.rdrobust(y=self._M_Y[:, self._i_rep], x=self._score, fuzzy=None, h=h, b=b, **self.kwargs)
         return rdd_res
 
     def _set_coefs(self, rdd_res, h):

--- a/doubleml/rdd/rdd.py
+++ b/doubleml/rdd/rdd.py
@@ -453,10 +453,12 @@ class RDFlex:
     def _fit_rdd(self, h=None, b=None):
         if self.fuzzy:
             rdd_res = rdrobust.rdrobust(
-                y=self._M_Y[:, self._i_rep], x=self._score, fuzzy=self._M_D[:, self._i_rep], h=h, b=b, c=0, **self.kwargs
+                y=self._M_Y[:, self._i_rep], x=self._score, fuzzy=self._M_D[:, self._i_rep],
+                c=0, **{{"h": h, "b": b} | self.kwargs}
             )
         else:
-            rdd_res = rdrobust.rdrobust(y=self._M_Y[:, self._i_rep], x=self._score, fuzzy=None, h=h, b=b, **self.kwargs)
+            rdd_res = rdrobust.rdrobust(y=self._M_Y[:, self._i_rep], x=self._score, fuzzy=None,
+                                        c=0, **{{"h": h, "b": b} | self.kwargs})
         return rdd_res
 
     def _set_coefs(self, rdd_res, h):

--- a/doubleml/rdd/rdd.py
+++ b/doubleml/rdd/rdd.py
@@ -143,9 +143,13 @@ class RDFlex:
 
         self._check_effect_sign()
 
-        if ("h", "b") & kwargs.keys():
-            warnings.warn(f"Key-worded arguments contain: {('h', 'b') & kwargs.keys()}. \n \
-                            Iterative bandwidth selection will be overwritten by provided values.")
+        if found_keys := {"h", "b"} & kwargs.keys():
+            warnings.warn(
+                (
+                    f"Key-worded arguments contain: {found_keys}.\n"
+                    "Iterative bandwidth selection will be overwritten by provided values."
+                )
+            )
 
         self.kwargs = kwargs
 
@@ -456,12 +460,16 @@ class RDFlex:
     def _fit_rdd(self, h=None, b=None):
         if self.fuzzy:
             rdd_res = rdrobust.rdrobust(
-                y=self._M_Y[:, self._i_rep], x=self._score, fuzzy=self._M_D[:, self._i_rep],
-                c=0, **({"h": h, "b": b} | self.kwargs)
+                y=self._M_Y[:, self._i_rep],
+                x=self._score,
+                fuzzy=self._M_D[:, self._i_rep],
+                c=0,
+                **({"h": h, "b": b} | self.kwargs),
             )
         else:
-            rdd_res = rdrobust.rdrobust(y=self._M_Y[:, self._i_rep], x=self._score, fuzzy=None,
-                                        c=0, **({"h": h, "b": b} | self.kwargs))
+            rdd_res = rdrobust.rdrobust(
+                y=self._M_Y[:, self._i_rep], x=self._score, fuzzy=None, c=0, **({"h": h, "b": b} | self.kwargs)
+            )
         return rdd_res
 
     def _set_coefs(self, rdd_res, h):

--- a/doubleml/rdd/rdd.py
+++ b/doubleml/rdd/rdd.py
@@ -143,7 +143,10 @@ class RDFlex:
 
         self._check_effect_sign()
 
-        # TODO: Add further input checks
+        if ("h", "b") & kwargs.keys():
+            warnings.warn(f"Key-worded arguments contain: {('h', 'b') & kwargs.keys()}. \n \
+                            Iterative bandwidth selection will be overwritten by provided values.")
+
         self.kwargs = kwargs
 
         self._smpls = DoubleMLResampling(
@@ -454,11 +457,11 @@ class RDFlex:
         if self.fuzzy:
             rdd_res = rdrobust.rdrobust(
                 y=self._M_Y[:, self._i_rep], x=self._score, fuzzy=self._M_D[:, self._i_rep],
-                c=0, **{{"h": h, "b": b} | self.kwargs}
+                c=0, **({"h": h, "b": b} | self.kwargs)
             )
         else:
             rdd_res = rdrobust.rdrobust(y=self._M_Y[:, self._i_rep], x=self._score, fuzzy=None,
-                                        c=0, **{{"h": h, "b": b} | self.kwargs})
+                                        c=0, **({"h": h, "b": b} | self.kwargs))
         return rdd_res
 
     def _set_coefs(self, rdd_res, h):

--- a/doubleml/rdd/tests/test_rdd_exceptions.py
+++ b/doubleml/rdd/tests/test_rdd_exceptions.py
@@ -237,3 +237,22 @@ def test_rdd_exception_fit():
     msg = "The number of iterations for the iterative bandwidth fitting has to be positive. 0 was passed."
     with pytest.raises(ValueError, match=msg):
         rdd_model.fit(n_iterations=0)
+
+
+@pytest.mark.ci_rdd
+def test_rdd_warning_kwargs():
+    msg = r"Key-worded arguments contain: {'h'}.\n" "Iterative bandwidth selection will be overwritten by provided values."
+    with pytest.warns(UserWarning, match=msg):
+        _ = RDFlex(dml_data, ml_g, h=0.1)
+
+    msg = r"Key-worded arguments contain: {'b'}.\n" "Iterative bandwidth selection will be overwritten by provided values."
+    with pytest.warns(UserWarning, match=msg):
+        _ = RDFlex(dml_data, ml_g, b=0.1)
+
+    # The order in the set is not guaranteed
+    msg = (
+        r"Key-worded arguments contain: {'[hb]', '[hb]'}.\n"
+        "Iterative bandwidth selection will be overwritten by provided values."
+    )
+    with pytest.warns(UserWarning, match=msg):
+        _ = RDFlex(dml_data, ml_g, h=0.1, b=0.1)


### PR DESCRIPTION
### Description
Add the possibility to set "h" and "b" as kwargs in `RDFlex`

### Reference to Issues or PRs
Requested in #341 

### Comments
Not recommended to set because of iterative bandwidth selection in RDFlex, warning is included.


### PR Checklist

- [x] The title of the pull request summarizes the changes made.
- [x] The PR contains a detailed description of all changes and additions.
- [x] References to related issues or PRs are added.
- [x] The code passes all (unit) tests.
- [x] Enhancements or new feature are equipped with unit tests.
- [x] The changes adhere to the PEP8 standards.
