### PR TITLE
Enable CATEs and GATEs for multiple repetitions

### DIFF
--- a/doubleml/irm/apo.py
+++ b/doubleml/irm/apo.py
@@ -579,11 +579,9 @@ class DoubleMLAPO(LinearScoreMixin, DoubleML):
         if self.score not in valid_score:
             raise ValueError("Invalid score " + self.score + ". " + "Valid score " + " or ".join(valid_score) + ".")
 
-        if self.n_rep != 1:
-            raise NotImplementedError("Only implemented for one repetition. " + f"Number of repetitions is {str(self.n_rep)}.")
-
         # define the orthogonal signal
-        orth_signal = self.psi_elements["psi_b"].reshape(-1)
+        orth_signal = np.squeeze(self.psi_elements["psi_b"], axis=2)
+
         # fit the best linear predictor
         model = DoubleMLBLP(orth_signal, basis=basis, is_gate=is_gate)
         model.fit(**kwargs)

--- a/doubleml/irm/irm.py
+++ b/doubleml/irm/irm.py
@@ -587,11 +587,9 @@ class DoubleMLIRM(LinearScoreMixin, DoubleML):
         if self.score not in valid_score:
             raise ValueError("Invalid score " + self.score + ". " + "Valid score " + " or ".join(valid_score) + ".")
 
-        if self.n_rep != 1:
-            raise NotImplementedError("Only implemented for one repetition. " + f"Number of repetitions is {str(self.n_rep)}.")
-
         # define the orthogonal signal
-        orth_signal = self.psi_elements["psi_b"].reshape(-1)
+        orth_signal = np.squeeze(self.psi_elements["psi_b"], axis=2)
+
         # fit the best linear predictor
         model = DoubleMLBLP(orth_signal, basis=basis, is_gate=is_gate)
         model.fit(**kwargs)

--- a/doubleml/irm/tests/test_apo.py
+++ b/doubleml/irm/tests/test_apo.py
@@ -279,3 +279,48 @@ def test_dml_apo_capo_gapo(treatment_level, cov_type):
     assert isinstance(gapo_2.confint(), pd.DataFrame)
     assert all(gapo_2.confint().index == ["Group_1", "Group_2"])
     assert gapo_2.blp_model.cov_type == cov_type
+
+
+@pytest.mark.ci
+def test_dml_apo_capo_gapo_multiple_rep(treatment_level, cov_type):
+    n = 120
+    np.random.seed(42)
+    obj_dml_data = make_irm_data(n_obs=n, dim_x=2)
+
+    ml_g = RandomForestRegressor(n_estimators=10, random_state=42)
+    ml_m = RandomForestClassifier(n_estimators=10, random_state=42)
+
+    dml_obj = dml.DoubleMLAPO(
+        obj_dml_data,
+        ml_m=ml_m,
+        ml_g=ml_g,
+        treatment_level=treatment_level,
+        ps_processor_config=PSProcessorConfig(clipping_threshold=0.05),
+        n_folds=3,
+        n_rep=2,
+    )
+
+    dml_obj.fit()
+
+    random_basis = pd.DataFrame(np.random.normal(0, 1, size=(n, 5)))
+    capo = dml_obj.capo(random_basis, cov_type=cov_type)
+    assert isinstance(capo, dml.utils.blp.DoubleMLBLP)
+    assert capo.n_rep == 2
+    assert isinstance(capo.blp_model, list)
+    assert len(capo.blp_model) == 2
+    assert capo.blp_model[0].cov_type == cov_type
+    assert capo.blp_model[1].cov_type == cov_type
+    assert capo.all_coef.shape == (random_basis.shape[1], 2)
+    assert capo.all_se.shape == (random_basis.shape[1], 2)
+    assert isinstance(capo.confint(), pd.DataFrame)
+    assert isinstance(capo.summary, pd.DataFrame)
+
+    x1 = obj_dml_data.data["X1"]
+    groups = pd.DataFrame({"Group 1": x1 <= x1.median(), "Group 2": x1 > x1.median()})
+    gapo = dml_obj.gapo(groups, cov_type=cov_type)
+    assert isinstance(gapo, dml.utils.blp.DoubleMLBLP)
+    assert gapo.n_rep == 2
+    assert gapo.all_coef.shape == (groups.shape[1], 2)
+    assert gapo.all_se.shape == (groups.shape[1], 2)
+    assert isinstance(gapo.confint(), pd.DataFrame)
+    assert all(gapo.confint().index == groups.columns.to_list())

--- a/doubleml/irm/tests/test_apo.py
+++ b/doubleml/irm/tests/test_apo.py
@@ -257,7 +257,7 @@ def test_dml_apo_capo_gapo(treatment_level, cov_type):
     capo = dml_obj.capo(random_basis, cov_type=cov_type)
     assert isinstance(capo, dml.utils.blp.DoubleMLBLP)
     assert isinstance(capo.confint(), pd.DataFrame)
-    assert capo.blp_model.cov_type == cov_type
+    assert capo.blp_model[0].cov_type == cov_type
 
     groups_1 = pd.DataFrame(
         np.column_stack([obj_dml_data.data["X1"] <= -1.0, obj_dml_data.data["X1"] > 0.2]), columns=["Group 1", "Group 2"]
@@ -268,7 +268,7 @@ def test_dml_apo_capo_gapo(treatment_level, cov_type):
     assert isinstance(gapo_1, dml.utils.blp.DoubleMLBLP)
     assert isinstance(gapo_1.confint(), pd.DataFrame)
     assert all(gapo_1.confint().index == groups_1.columns.to_list())
-    assert gapo_1.blp_model.cov_type == cov_type
+    assert gapo_1.blp_model[0].cov_type == cov_type
 
     np.random.seed(42)
     groups_2 = pd.DataFrame(np.random.choice(["1", "2"], n, p=[0.1, 0.9]))
@@ -278,7 +278,7 @@ def test_dml_apo_capo_gapo(treatment_level, cov_type):
     assert isinstance(gapo_2, dml.utils.blp.DoubleMLBLP)
     assert isinstance(gapo_2.confint(), pd.DataFrame)
     assert all(gapo_2.confint().index == ["Group_1", "Group_2"])
-    assert gapo_2.blp_model.cov_type == cov_type
+    assert gapo_2.blp_model[0].cov_type == cov_type
 
 
 @pytest.mark.ci

--- a/doubleml/irm/tests/test_apo_exceptions.py
+++ b/doubleml/irm/tests/test_apo_exceptions.py
@@ -202,13 +202,6 @@ def test_apo_exception_capo_gapo():
     # reset the score
     dml_obj._score = "APO"
 
-    msg = "Only implemented for one repetition. Number of repetitions is 2."
-    with pytest.raises(NotImplementedError, match=msg):
-        dml_obj._n_rep = 2
-        dml_obj.capo(random_basis)
-    # reset the number of repetitions
-    dml_obj._n_rep = 1
-
     msg = "Groups must be of DataFrame type. Groups of type <class 'int'> was passed."
     with pytest.raises(TypeError, match=msg):
         _ = dml_obj.gapo(1)

--- a/doubleml/irm/tests/test_irm.py
+++ b/doubleml/irm/tests/test_irm.py
@@ -246,7 +246,7 @@ def test_dml_irm_cate_gate(cov_type):
     cate = dml_irm_obj.cate(random_basis, cov_type=cov_type)
     assert isinstance(cate, dml.utils.blp.DoubleMLBLP)
     assert isinstance(cate.confint(), pd.DataFrame)
-    assert cate.blp_model.cov_type == cov_type
+    assert cate.blp_model[0].cov_type == cov_type
 
     groups_1 = pd.DataFrame(
         np.column_stack([obj_dml_data.data["X1"] <= 0, obj_dml_data.data["X1"] > 0.2]), columns=["Group 1", "Group 2"]
@@ -257,7 +257,7 @@ def test_dml_irm_cate_gate(cov_type):
     assert isinstance(gate_1, dml.utils.blp.DoubleMLBLP)
     assert isinstance(gate_1.confint(), pd.DataFrame)
     assert all(gate_1.confint().index == groups_1.columns.to_list())
-    assert gate_1.blp_model.cov_type == cov_type
+    assert gate_1.blp_model[0].cov_type == cov_type
 
     np.random.seed(42)
     groups_2 = pd.DataFrame(np.random.choice(["1", "2"], n))
@@ -267,7 +267,7 @@ def test_dml_irm_cate_gate(cov_type):
     assert isinstance(gate_2, dml.utils.blp.DoubleMLBLP)
     assert isinstance(gate_2.confint(), pd.DataFrame)
     assert all(gate_2.confint().index == ["Group_1", "Group_2"])
-    assert gate_2.blp_model.cov_type == cov_type
+    assert gate_2.blp_model[0].cov_type == cov_type
 
 
 @pytest.mark.ci

--- a/doubleml/irm/tests/test_irm.py
+++ b/doubleml/irm/tests/test_irm.py
@@ -270,6 +270,49 @@ def test_dml_irm_cate_gate(cov_type):
     assert gate_2.blp_model.cov_type == cov_type
 
 
+@pytest.mark.ci
+def test_dml_irm_cate_gate_multiple_rep(cov_type):
+    n = 120
+    np.random.seed(42)
+    obj_dml_data = make_irm_data(n_obs=n, dim_x=2)
+
+    ml_g = RandomForestRegressor(n_estimators=10, random_state=42)
+    ml_m = RandomForestClassifier(n_estimators=10, random_state=42)
+    ps_processor_config = PSProcessorConfig(clipping_threshold=0.05)
+    dml_irm_obj = dml.DoubleMLIRM(
+        obj_dml_data,
+        ml_m=ml_m,
+        ml_g=ml_g,
+        ps_processor_config=ps_processor_config,
+        n_folds=3,
+        n_rep=2,
+    )
+
+    dml_irm_obj.fit()
+    random_basis = pd.DataFrame(np.random.normal(0, 1, size=(n, 5)))
+    cate = dml_irm_obj.cate(random_basis, cov_type=cov_type)
+    assert isinstance(cate, dml.utils.blp.DoubleMLBLP)
+    assert cate.n_rep == 2
+    assert isinstance(cate.blp_model, list)
+    assert len(cate.blp_model) == 2
+    assert cate.blp_model[0].cov_type == cov_type
+    assert cate.blp_model[1].cov_type == cov_type
+    assert cate.all_coef.shape == (random_basis.shape[1], 2)
+    assert cate.all_se.shape == (random_basis.shape[1], 2)
+    assert isinstance(cate.confint(), pd.DataFrame)
+    assert isinstance(cate.summary, pd.DataFrame)
+
+    x1 = obj_dml_data.data["X1"]
+    groups = pd.DataFrame({"Group 1": x1 <= x1.median(), "Group 2": x1 > x1.median()})
+    gate = dml_irm_obj.gate(groups, cov_type=cov_type)
+    assert isinstance(gate, dml.utils.blp.DoubleMLBLP)
+    assert gate.n_rep == 2
+    assert gate.all_coef.shape == (groups.shape[1], 2)
+    assert gate.all_se.shape == (groups.shape[1], 2)
+    assert isinstance(gate.confint(), pd.DataFrame)
+    assert all(gate.confint().index == groups.columns.to_list())
+
+
 @pytest.fixture(scope="module", params=[1, 3])
 def n_rep(request):
     return request.param

--- a/doubleml/plm/plr.py
+++ b/doubleml/plm/plr.py
@@ -470,14 +470,12 @@ class DoubleMLPLR(LinearScoreMixin, DoubleML):
             raise NotImplementedError(
                 "Only implemented for single treatment. " + f"Number of treatments is {str(self._dml_data.n_treat)}."
             )
-        if self.n_rep != 1:
-            raise NotImplementedError("Only implemented for one repetition. " + f"Number of repetitions is {str(self.n_rep)}.")
 
         Y_tilde, D_tilde = self._partial_out()
 
         D_basis = basis * D_tilde
         model = DoubleMLBLP(
-            orth_signal=Y_tilde.reshape(-1),
+            orth_signal=Y_tilde,
             basis=D_basis,
             is_gate=is_gate,
         )

--- a/doubleml/plm/tests/test_plr.py
+++ b/doubleml/plm/tests/test_plr.py
@@ -337,3 +337,45 @@ def test_dml_plr_cate_gate(score, cov_type):
     assert isinstance(gate_2.confint(), pd.DataFrame)
     assert all(gate_2.confint().index == ["Group_1", "Group_2"])
     assert gate_2.blp_model.cov_type == cov_type
+
+
+@pytest.mark.ci
+def test_dml_plr_cate_gate_multiple_rep(score, cov_type):
+    n = 120
+
+    np.random.seed(42)
+    obj_dml_data = dml.plm.datasets.make_plr_CCDDHNR2018(n_obs=n)
+    ml_l = LinearRegression()
+    ml_g = LinearRegression()
+    ml_m = LinearRegression()
+
+    if score == "partialling out":
+        dml_plr_obj = dml.DoubleMLPLR(obj_dml_data, ml_l=ml_l, ml_m=ml_m, n_folds=3, n_rep=2, score=score)
+    else:
+        assert score == "IV-type"
+        dml_plr_obj = dml.DoubleMLPLR(obj_dml_data, ml_l=ml_l, ml_m=ml_m, ml_g=ml_g, n_folds=3, n_rep=2, score=score)
+
+    dml_plr_obj.fit()
+
+    random_basis = pd.DataFrame(np.random.normal(0, 1, size=(n, 2)))
+    cate = dml_plr_obj.cate(random_basis, cov_type=cov_type)
+    assert isinstance(cate, dml.DoubleMLBLP)
+    assert cate.n_rep == 2
+    assert isinstance(cate.blp_model, list)
+    assert len(cate.blp_model) == 2
+    assert cate.blp_model[0].cov_type == cov_type
+    assert cate.blp_model[1].cov_type == cov_type
+    assert cate.all_coef.shape == (random_basis.shape[1], 2)
+    assert cate.all_se.shape == (random_basis.shape[1], 2)
+    assert isinstance(cate.confint(), pd.DataFrame)
+    assert isinstance(cate.summary, pd.DataFrame)
+
+    x1 = obj_dml_data.data["X1"]
+    groups = pd.DataFrame({"Group 1": x1 <= x1.median(), "Group 2": x1 > x1.median()})
+    gate = dml_plr_obj.gate(groups, cov_type=cov_type)
+    assert isinstance(gate, dml.DoubleMLBLP)
+    assert gate.n_rep == 2
+    assert gate.all_coef.shape == (groups.shape[1], 2)
+    assert gate.all_se.shape == (groups.shape[1], 2)
+    assert isinstance(gate.confint(), pd.DataFrame)
+    assert all(gate.confint().index == groups.columns.tolist())

--- a/doubleml/plm/tests/test_plr.py
+++ b/doubleml/plm/tests/test_plr.py
@@ -315,7 +315,7 @@ def test_dml_plr_cate_gate(score, cov_type):
     cate = dml_plr_obj.cate(random_basis, cov_type=cov_type)
     assert isinstance(cate, dml.DoubleMLBLP)
     assert isinstance(cate.confint(), pd.DataFrame)
-    assert cate.blp_model.cov_type == cov_type
+    assert cate.blp_model[0].cov_type == cov_type
 
     groups_1 = pd.DataFrame(
         np.column_stack([obj_dml_data.data["X1"] <= 0, obj_dml_data.data["X1"] > 0.2]), columns=["Group 1", "Group 2"]
@@ -326,7 +326,7 @@ def test_dml_plr_cate_gate(score, cov_type):
     assert isinstance(gate_1, dml.utils.blp.DoubleMLBLP)
     assert isinstance(gate_1.confint(), pd.DataFrame)
     assert all(gate_1.confint().index == groups_1.columns.tolist())
-    assert gate_1.blp_model.cov_type == cov_type
+    assert gate_1.blp_model[0].cov_type == cov_type
 
     np.random.seed(42)
     groups_2 = pd.DataFrame(np.random.choice(["1", "2"], n))
@@ -336,7 +336,7 @@ def test_dml_plr_cate_gate(score, cov_type):
     assert isinstance(gate_2, dml.utils.blp.DoubleMLBLP)
     assert isinstance(gate_2.confint(), pd.DataFrame)
     assert all(gate_2.confint().index == ["Group_1", "Group_2"])
-    assert gate_2.blp_model.cov_type == cov_type
+    assert gate_2.blp_model[0].cov_type == cov_type
 
 
 @pytest.mark.ci

--- a/doubleml/plm/tests/test_plr_binary_outcome.py
+++ b/doubleml/plm/tests/test_plr_binary_outcome.py
@@ -231,7 +231,7 @@ def test_dml_plr_binary_cate_gate(score, cov_type, generate_binary_data):
     cate = dml_plr_obj.cate(random_basis, cov_type=cov_type)
     assert isinstance(cate, dml.DoubleMLBLP)
     assert isinstance(cate.confint(), pd.DataFrame)
-    assert cate.blp_model.cov_type == cov_type
+    assert cate.blp_model[0].cov_type == cov_type
 
     groups_1 = pd.DataFrame(np.column_stack([data["X1"] <= 0, data["X1"] > 0.2]), columns=["Group 1", "Group 2"])
     msg = "At least one group effect is estimated with less than 6 observations."
@@ -240,4 +240,4 @@ def test_dml_plr_binary_cate_gate(score, cov_type, generate_binary_data):
     assert isinstance(gate_1, dml.utils.blp.DoubleMLBLP)
     assert isinstance(gate_1.confint(), pd.DataFrame)
     assert all(gate_1.confint().index == groups_1.columns.tolist())
-    assert gate_1.blp_model.cov_type == cov_type
+    assert gate_1.blp_model[0].cov_type == cov_type

--- a/doubleml/tests/test_exceptions.py
+++ b/doubleml/tests/test_exceptions.py
@@ -1377,22 +1377,6 @@ def test_doubleml_exception_gate():
     with pytest.raises(ValueError, match=msg):
         dml_irm_obj.gate(groups=groups)
 
-    dml_irm_obj = DoubleMLIRM(
-        dml_data_irm,
-        ml_g=Lasso(),
-        ml_m=LogisticRegression(),
-        ps_processor_config=PSProcessorConfig(clipping_threshold=0.1),
-        n_folds=5,
-        score="ATE",
-        n_rep=2,
-    )
-    dml_irm_obj.fit()
-
-    msg = "Only implemented for one repetition. Number of repetitions is 2."
-    with pytest.raises(NotImplementedError, match=msg):
-        dml_irm_obj.gate(groups=groups)
-
-
 @pytest.mark.ci
 def test_doubleml_exception_cate():
     dml_irm_obj = DoubleMLIRM(
@@ -1419,8 +1403,8 @@ def test_doubleml_exception_cate():
         n_rep=2,
     )
     dml_irm_obj.fit()
-    msg = "Only implemented for one repetition. Number of repetitions is 2."
-    with pytest.raises(NotImplementedError, match=msg):
+    msg = "The basis must be of DataFrame type. Basis of type <class 'int'> was passed."
+    with pytest.raises(TypeError, match=msg):
         dml_irm_obj.cate(basis=2)
 
 
@@ -1428,8 +1412,8 @@ def test_doubleml_exception_cate():
 def test_doubleml_exception_plr_cate():
     dml_plr_obj = DoubleMLPLR(dml_data, ml_l=Lasso(), ml_m=Lasso(), n_folds=2, n_rep=2)
     dml_plr_obj.fit()
-    msg = "Only implemented for one repetition. Number of repetitions is 2."
-    with pytest.raises(NotImplementedError, match=msg):
+    msg = "The basis must be of DataFrame type. Basis of type <class 'numpy.ndarray'> was passed."
+    with pytest.raises(TypeError, match=msg):
         dml_plr_obj.cate(basis=2)
 
     dml_plr_obj = DoubleMLPLR(dml_data, ml_l=Lasso(), ml_m=Lasso(), n_folds=2)

--- a/doubleml/tests/test_exceptions.py
+++ b/doubleml/tests/test_exceptions.py
@@ -1377,6 +1377,20 @@ def test_doubleml_exception_gate():
     with pytest.raises(ValueError, match=msg):
         dml_irm_obj.gate(groups=groups)
 
+    dml_irm_obj = DoubleMLIRM(
+        dml_data_irm,
+        ml_g=Lasso(),
+        ml_m=LogisticRegression(),
+        ps_processor_config=PSProcessorConfig(clipping_threshold=0.1),
+        n_folds=5,
+        score="ATE",
+        n_rep=2,
+    )
+    dml_irm_obj.fit()
+    msg = "Groups must be of DataFrame type. Groups of type <class 'int'> was passed."
+    with pytest.raises(TypeError, match=msg):
+        dml_irm_obj.gate(groups=2)
+
 @pytest.mark.ci
 def test_doubleml_exception_cate():
     dml_irm_obj = DoubleMLIRM(
@@ -1443,6 +1457,12 @@ def test_doubleml_exception_plr_gate():
     )
     with pytest.raises(TypeError, match=msg):
         dml_plr_obj.gate(groups=pd.DataFrame(np.random.normal(0, 1, size=(dml_data.n_obs, 3))))
+
+    dml_plr_obj = DoubleMLPLR(dml_data, ml_l=Lasso(), ml_m=Lasso(), n_folds=2, n_rep=2)
+    dml_plr_obj.fit()
+    msg = "Groups must be of DataFrame type. Groups of type <class 'int'> was passed."
+    with pytest.raises(TypeError, match=msg):
+        dml_plr_obj.gate(groups=2)
 
 
 @pytest.mark.ci

--- a/doubleml/tests/test_exceptions.py
+++ b/doubleml/tests/test_exceptions.py
@@ -1391,6 +1391,7 @@ def test_doubleml_exception_gate():
     with pytest.raises(TypeError, match=msg):
         dml_irm_obj.gate(groups=2)
 
+
 @pytest.mark.ci
 def test_doubleml_exception_cate():
     dml_irm_obj = DoubleMLIRM(

--- a/doubleml/utils/blp.py
+++ b/doubleml/utils/blp.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import statsmodels.api as sm
 from scipy.linalg import sqrtm
-from scipy.stats import norm, t
+from scipy.stats import norm
 
 from ._estimation import _aggregate_coefs_and_ses
 
@@ -161,7 +161,7 @@ class DoubleMLBLP:
         if self.blp_model is None:
             df_summary = pd.DataFrame(columns=col_names)
         else:
-            critical_value = t.ppf(0.975, self._blp_model[0].df_resid) if self._blp_model[0].use_t else norm.ppf(0.975)
+            conf_int_values = [self._blp_model[i].conf_int() for i in range(self.n_rep)]
             t_values = np.divide(self.coef, self.se)
             p_values = 2 * norm.cdf(-np.abs(t_values))
             summary_stats = {
@@ -169,8 +169,8 @@ class DoubleMLBLP:
                 "std err": self.se,
                 "t": t_values,
                 "P>|t|": p_values,
-                "[0.025": self.coef - critical_value * self.se,
-                "0.975]": self.coef + critical_value * self.se,
+                "[0.025": np.median([conf_int_values[i][0] for i in range(self.n_rep)], axis=0),
+                "0.975]": np.median([conf_int_values[i][1] for i in range(self.n_rep)], axis=0),
             }
             df_summary = pd.DataFrame(summary_stats, columns=col_names, index=self._basis.columns)
         return df_summary
@@ -271,11 +271,9 @@ class DoubleMLBLP:
                 if joint:
                     warnings.warn("Returning pointwise confidence intervals for basis coefficients.", UserWarning)
                 # return the confidence intervals for the basis coefficients
-                critical_value = (
-                    t.ppf(1 - alpha / 2, self._blp_model[0].df_resid) if self._blp_model[0].use_t else norm.ppf(1 - alpha / 2)
-                )
-                ci_lower = self.coef - critical_value * self.se
-                ci_upper = self.coef + critical_value * self.se
+                conf_int_values = [self._blp_model[i].conf_int(alpha=alpha) for i in range(self.n_rep)]
+                ci_lower = np.median([conf_int_values[i][0] for i in range(self.n_rep)], axis=0)
+                ci_upper = np.median([conf_int_values[i][1] for i in range(self.n_rep)], axis=0)
                 ci = np.vstack((ci_lower, self.coef, ci_upper)).T
                 df_ci = pd.DataFrame(
                     ci,
@@ -292,31 +290,27 @@ class DoubleMLBLP:
             raise ValueError("Invalid basis: DataFrame has to have the exact same number and ordering of columns.")
 
         # blp of the orthogonal signal
-        g_hat, blp_se, _, _ = self._predict_and_aggregate(basis)
+        g_hat, _, all_g_hat, all_blp_se = self._predict_and_aggregate(basis)
 
         if joint:
             np_basis = basis.to_numpy()
-            bootstrap_samples = np.full((basis.shape[0], self.n_rep, n_rep_boot), np.nan)
+            critical_values = np.full(self.n_rep, np.nan)
+
             for i_rep in range(self.n_rep):
                 normal_samples = np.random.normal(size=[basis.shape[1], n_rep_boot])
-                omega_sqrt = np.real(sqrtm(self._blp_omega[:, :, i_rep]))
-                bootstrap_samples[:, i_rep, :] = np.dot(np_basis, np.dot(omega_sqrt, normal_samples))
-
-            # aggregate the draws over repetitions according to the median aggregation rule
-            bootstrap_samples = np.divide(np.median(bootstrap_samples, axis=1), blp_se.reshape(-1, 1))
-
-            max_t_stat = np.quantile(np.max(np.abs(bootstrap_samples), axis=1), q=level)
-
-            # Lower simultaneous CI
-            g_hat_lower = g_hat - max_t_stat * blp_se
-            # Upper simultaneous CI
-            g_hat_upper = g_hat + max_t_stat * blp_se
-
+                omega_sqrt = sqrtm(self._blp_omega[:, :, i_rep])
+                bootstrap_samples = np.multiply(
+                    np.dot(np_basis, np.dot(omega_sqrt, normal_samples)).T, (1.0 / all_blp_se[:, i_rep])
+                )
+                critical_values[i_rep] = np.quantile(np.max(np.abs(bootstrap_samples), axis=0), q=level)
         else:
-            # Lower point-wise CI
-            g_hat_lower = g_hat + norm.ppf(q=alpha / 2) * blp_se
-            # Upper point-wise CI
-            g_hat_upper = g_hat + norm.ppf(q=1 - alpha / 2) * blp_se
+            critical_values = np.repeat(norm.ppf(q=1 - alpha / 2), self.n_rep)
+
+        all_g_hat_lower = all_g_hat - critical_values * all_blp_se
+        all_g_hat_upper = all_g_hat + critical_values * all_blp_se
+
+        g_hat_lower = np.median(all_g_hat_lower, axis=1)
+        g_hat_upper = np.median(all_g_hat_upper, axis=1)
 
         ci = np.vstack((g_hat_lower, g_hat, g_hat_upper)).T
         df_ci = pd.DataFrame(

--- a/doubleml/utils/blp.py
+++ b/doubleml/utils/blp.py
@@ -73,20 +73,11 @@ class DoubleMLBLP:
     @property
     def blp_model(self):
         """
-        Best-Linear-Predictor model.
-        For multiple repetitions this is a list with one model per repetition.
+        Best-Linear-Predictor models.
+        This is a list with one model per repetition.
         """
         if self._blp_model is None:
             return None
-        if self.n_rep == 1:
-            return self._blp_model[0]
-        return self._blp_model
-
-    @property
-    def blp_models(self):
-        """
-        Best-Linear-Predictor models for each repetition.
-        """
         return self._blp_model
 
     @property
@@ -94,8 +85,6 @@ class DoubleMLBLP:
         """
         Orthogonal signal.
         """
-        if self.n_rep == 1:
-            return self._orth_signal.reshape(-1)
         return self._orth_signal
 
     @property
@@ -120,8 +109,6 @@ class DoubleMLBLP:
         """
         if self._blp_omega is None:
             return None
-        if self.n_rep == 1:
-            return self._blp_omega[:, :, 0]
         return self._blp_omega
 
     @property

--- a/doubleml/utils/blp.py
+++ b/doubleml/utils/blp.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import statsmodels.api as sm
 from scipy.linalg import sqrtm
-from scipy.stats import norm
+from scipy.stats import norm, t
 
 from ._estimation import _aggregate_coefs_and_ses
 
@@ -160,18 +160,8 @@ class DoubleMLBLP:
         col_names = ["coef", "std err", "t", "P>|t|", "[0.025", "0.975]"]
         if self.blp_model is None:
             df_summary = pd.DataFrame(columns=col_names)
-        elif self.n_rep == 1:
-            summary_stats = {
-                "coef": self.blp_model.params,
-                "std err": self.blp_model.bse,
-                "t": self.blp_model.tvalues,
-                "P>|t|": self.blp_model.pvalues,
-                "[0.025": self.blp_model.conf_int()[0],
-                "0.975]": self.blp_model.conf_int()[1],
-            }
-            df_summary = pd.DataFrame(summary_stats, columns=col_names)
         else:
-            critical_value = norm.ppf(0.975)
+            critical_value = t.ppf(0.975, self._blp_model[0].df_resid) if self._blp_model[0].use_t else norm.ppf(0.975)
             t_values = np.divide(self.coef, self.se)
             p_values = 2 * norm.cdf(-np.abs(t_values))
             summary_stats = {
@@ -281,21 +271,12 @@ class DoubleMLBLP:
                 if joint:
                     warnings.warn("Returning pointwise confidence intervals for basis coefficients.", UserWarning)
                 # return the confidence intervals for the basis coefficients
-                if self.n_rep == 1:
-                    ci = np.vstack(
-                        (
-                            self.blp_model.conf_int(alpha=alpha / 2)[0],
-                            self.blp_model.params,
-                            self.blp_model.conf_int(alpha=alpha / 2)[1],
-                        )
-                    ).T
-                else:
-                    critical_value = norm.ppf(1 - alpha / 2)
-                    all_ci_lower = self.all_coef - critical_value * self.all_se
-                    all_ci_upper = self.all_coef + critical_value * self.all_se
-                    ci_lower = np.median(all_ci_lower, axis=1)
-                    ci_upper = np.median(all_ci_upper, axis=1)
-                    ci = np.vstack((ci_lower, self.coef, ci_upper)).T
+                critical_value = (
+                    t.ppf(1 - alpha / 2, self._blp_model[0].df_resid) if self._blp_model[0].use_t else norm.ppf(1 - alpha / 2)
+                )
+                ci_lower = self.coef - critical_value * self.se
+                ci_upper = self.coef + critical_value * self.se
+                ci = np.vstack((ci_lower, self.coef, ci_upper)).T
                 df_ci = pd.DataFrame(
                     ci,
                     columns=["{:.1f} %".format(alpha / 2 * 100), "effect", "{:.1f} %".format((1 - alpha / 2) * 100)],
@@ -315,22 +296,16 @@ class DoubleMLBLP:
 
         if joint:
             np_basis = basis.to_numpy()
-            if self.n_rep == 1:
-                # calculate the maximum t-statistic with bootstrap
+            bootstrap_samples = np.full((basis.shape[0], self.n_rep, n_rep_boot), np.nan)
+            for i_rep in range(self.n_rep):
                 normal_samples = np.random.normal(size=[basis.shape[1], n_rep_boot])
-                omega_sqrt = np.real(sqrtm(self.blp_omega))
-                bootstrap_samples = np.multiply(np.dot(np_basis, np.dot(omega_sqrt, normal_samples)).T, (1.0 / blp_se))
-            else:
-                bootstrap_samples = np.full((basis.shape[0], self.n_rep, n_rep_boot), np.nan)
-                for i_rep in range(self.n_rep):
-                    normal_samples = np.random.normal(size=[basis.shape[1], n_rep_boot])
-                    omega_sqrt = np.real(sqrtm(self._blp_omega[:, :, i_rep]))
-                    bootstrap_samples[:, i_rep, :] = np.dot(np_basis, np.dot(omega_sqrt, normal_samples))
+                omega_sqrt = np.real(sqrtm(self._blp_omega[:, :, i_rep]))
+                bootstrap_samples[:, i_rep, :] = np.dot(np_basis, np.dot(omega_sqrt, normal_samples))
 
-                # aggregate the draws over repetitions according to the median aggregation rule
-                bootstrap_samples = np.divide(np.median(bootstrap_samples, axis=1), blp_se.reshape(-1, 1))
+            # aggregate the draws over repetitions according to the median aggregation rule
+            bootstrap_samples = np.divide(np.median(bootstrap_samples, axis=1), blp_se.reshape(-1, 1))
 
-            max_t_stat = np.quantile(np.max(np.abs(bootstrap_samples), axis=0), q=level)
+            max_t_stat = np.quantile(np.max(np.abs(bootstrap_samples), axis=1), q=level)
 
             # Lower simultaneous CI
             g_hat_lower = g_hat - max_t_stat * blp_se

--- a/doubleml/utils/blp.py
+++ b/doubleml/utils/blp.py
@@ -6,6 +6,8 @@ import statsmodels.api as sm
 from scipy.linalg import sqrtm
 from scipy.stats import norm
 
+from ._estimation import _aggregate_coefs_and_ses
+
 
 class DoubleMLBLP:
     """Best linear predictor (BLP) for DoubleML with orthogonal signals.
@@ -14,8 +16,8 @@ class DoubleMLBLP:
     Parameters
     ----------
     orth_signal : :class:`numpy.array`
-        The orthogonal signal to be predicted. Has to be of shape ``(n_obs,)``,
-        where ``n_obs`` is the number of observations.
+        The orthogonal signal to be predicted. Has to be of shape ``(n_obs,)`` or ``(n_obs, n_rep)``,
+        where ``n_obs`` is the number of observations and ``n_rep`` is the number of repetitions.
 
     basis : :class:`pandas.DataFrame`
         The basis for estimating the best linear predictor. Has to have the shape ``(n_obs, d)``,
@@ -30,24 +32,36 @@ class DoubleMLBLP:
         if not isinstance(orth_signal, np.ndarray):
             raise TypeError(f"The signal must be of np.ndarray type. Signal of type {str(type(orth_signal))} was passed.")
 
-        if orth_signal.ndim != 1:
+        if orth_signal.ndim not in [1, 2]:
             raise ValueError(
-                f"The signal must be of one dimensional. Signal of dimensions {str(orth_signal.ndim)} was passed."
+                f"The signal must be one- or two-dimensional. Signal of dimensions {str(orth_signal.ndim)} was passed."
             )
+
+        if orth_signal.ndim == 1:
+            self._orth_signal = orth_signal.reshape(-1, 1)
+        else:
+            self._orth_signal = orth_signal
+        self._n_rep = self._orth_signal.shape[1]
+        self._is_gate = is_gate
 
         if not isinstance(basis, pd.DataFrame):
             raise TypeError(f"The basis must be of DataFrame type. Basis of type {str(type(basis))} was passed.")
-
         if not basis.columns.is_unique:
             raise ValueError("Invalid pd.DataFrame: Contains duplicate column names.")
-
-        self._orth_signal = orth_signal
+        if self._orth_signal.shape[0] != basis.shape[0]:
+            raise ValueError(
+                "The number of observations in signal and basis does not match. "
+                f"Got {str(self._orth_signal.shape[0])} and {str(basis.shape[0])}."
+            )
         self._basis = basis
-        self._is_gate = is_gate
 
         # initialize the score and the covariance
         self._blp_model = None
         self._blp_omega = None
+        self._all_coef = None
+        self._all_se = None
+        self._coef = None
+        self._se = None
 
     def __str__(self):
         class_name = self.__class__.__name__
@@ -60,6 +74,18 @@ class DoubleMLBLP:
     def blp_model(self):
         """
         Best-Linear-Predictor model.
+        For multiple repetitions this is a list with one model per repetition.
+        """
+        if self._blp_model is None:
+            return None
+        if self.n_rep == 1:
+            return self._blp_model[0]
+        return self._blp_model
+
+    @property
+    def blp_models(self):
+        """
+        Best-Linear-Predictor models for each repetition.
         """
         return self._blp_model
 
@@ -68,6 +94,8 @@ class DoubleMLBLP:
         """
         Orthogonal signal.
         """
+        if self.n_rep == 1:
+            return self._orth_signal.reshape(-1)
         return self._orth_signal
 
     @property
@@ -78,11 +106,51 @@ class DoubleMLBLP:
         return self._basis
 
     @property
+    def n_rep(self):
+        """
+        Number of repetitions.
+        """
+        return self._n_rep
+
+    @property
     def blp_omega(self):
         """
         Covariance matrix.
+        For multiple repetitions this has shape ``(d, d, n_rep)``.
         """
+        if self._blp_omega is None:
+            return None
+        if self.n_rep == 1:
+            return self._blp_omega[:, :, 0]
         return self._blp_omega
+
+    @property
+    def coef(self):
+        """
+        Aggregated coefficients over repetitions.
+        """
+        return self._coef
+
+    @property
+    def se(self):
+        """
+        Aggregated standard errors over repetitions.
+        """
+        return self._se
+
+    @property
+    def all_coef(self):
+        """
+        Coefficients for each repetition with shape ``(d, n_rep)``.
+        """
+        return self._all_coef
+
+    @property
+    def all_se(self):
+        """
+        Standard errors for each repetition with shape ``(d, n_rep)``.
+        """
+        return self._all_se
 
     @property
     def summary(self):
@@ -92,7 +160,7 @@ class DoubleMLBLP:
         col_names = ["coef", "std err", "t", "P>|t|", "[0.025", "0.975]"]
         if self.blp_model is None:
             df_summary = pd.DataFrame(columns=col_names)
-        else:
+        elif self.n_rep == 1:
             summary_stats = {
                 "coef": self.blp_model.params,
                 "std err": self.blp_model.bse,
@@ -102,6 +170,19 @@ class DoubleMLBLP:
                 "0.975]": self.blp_model.conf_int()[1],
             }
             df_summary = pd.DataFrame(summary_stats, columns=col_names)
+        else:
+            critical_value = norm.ppf(0.975)
+            t_values = np.divide(self.coef, self.se)
+            p_values = 2 * norm.cdf(-np.abs(t_values))
+            summary_stats = {
+                "coef": self.coef,
+                "std err": self.se,
+                "t": t_values,
+                "P>|t|": p_values,
+                "[0.025": self.coef - critical_value * self.se,
+                "0.975]": self.coef + critical_value * self.se,
+            }
+            df_summary = pd.DataFrame(summary_stats, columns=col_names, index=self._basis.columns)
         return df_summary
 
     def fit(self, cov_type="HC0", **kwargs):
@@ -123,8 +204,20 @@ class DoubleMLBLP:
         """
 
         # fit the best-linear-predictor of the orthogonal signal with respect to the grid
-        self._blp_model = sm.OLS(self._orth_signal, self._basis).fit(cov_type=cov_type, **kwargs)
-        self._blp_omega = self._blp_model.cov_params().to_numpy()
+        n_basis = self._basis.shape[1]
+        self._all_coef = np.full((n_basis, self.n_rep), np.nan)
+        self._all_se = np.full((n_basis, self.n_rep), np.nan)
+        self._blp_omega = np.full((n_basis, n_basis, self.n_rep), np.nan)
+        self._blp_model = []
+
+        for i_rep in range(self.n_rep):
+            blp_model = sm.OLS(self._orth_signal[:, i_rep], self._basis).fit(cov_type=cov_type, **kwargs)
+            self._blp_model.append(blp_model)
+            self._all_coef[:, i_rep] = np.asarray(blp_model.params)
+            self._all_se[:, i_rep] = np.asarray(blp_model.bse)
+            self._blp_omega[:, :, i_rep] = blp_model.cov_params().to_numpy()
+
+        self._coef, self._se = _aggregate_coefs_and_ses(self._all_coef, self._all_se)
 
         return self
 
@@ -188,13 +281,17 @@ class DoubleMLBLP:
                 if joint:
                     warnings.warn("Returning pointwise confidence intervals for basis coefficients.", UserWarning)
                 # return the confidence intervals for the basis coefficients
-                ci = np.vstack(
-                    (
-                        self.blp_model.conf_int(alpha=alpha / 2)[0],
-                        self.blp_model.params,
-                        self.blp_model.conf_int(alpha=alpha / 2)[1],
-                    )
-                ).T
+                if self.n_rep == 1:
+                    ci = np.vstack(
+                        (
+                            self.blp_model.conf_int(alpha=alpha / 2)[0],
+                            self.blp_model.params,
+                            self.blp_model.conf_int(alpha=alpha / 2)[1],
+                        )
+                    ).T
+                else:
+                    critical_value = norm.ppf(1 - alpha / 2)
+                    ci = np.vstack((self.coef - critical_value * self.se, self.coef, self.coef + critical_value * self.se)).T
                 df_ci = pd.DataFrame(
                     ci,
                     columns=["{:.1f} %".format(alpha / 2 * 100), "effect", "{:.1f} %".format((1 - alpha / 2) * 100)],
@@ -202,22 +299,32 @@ class DoubleMLBLP:
                 )
                 return df_ci
 
+        elif not isinstance(basis, pd.DataFrame):
+            raise TypeError(f"The basis must be of DataFrame type. Basis of type {str(type(basis))} was passed.")
         elif not (basis.shape[1] == self._basis.shape[1]):
             raise ValueError("Invalid basis: DataFrame has to have the exact same number and ordering of columns.")
         elif not list(basis.columns.values) == list(self._basis.columns.values):
             raise ValueError("Invalid basis: DataFrame has to have the exact same number and ordering of columns.")
 
         # blp of the orthogonal signal
-        g_hat = self._blp_model.predict(basis)
-
-        np_basis = basis.to_numpy()
-        # calculate se for basis elements
-        blp_se = np.sqrt((np.dot(np_basis, self._blp_omega) * np_basis).sum(axis=1))
+        g_hat, blp_se, _, _ = self._predict_and_aggregate(basis)
 
         if joint:
-            # calculate the maximum t-statistic with bootstrap
-            normal_samples = np.random.normal(size=[basis.shape[1], n_rep_boot])
-            bootstrap_samples = np.multiply(np.dot(np_basis, np.dot(sqrtm(self._blp_omega), normal_samples)).T, (1.0 / blp_se))
+            np_basis = basis.to_numpy()
+            if self.n_rep == 1:
+                # calculate the maximum t-statistic with bootstrap
+                normal_samples = np.random.normal(size=[basis.shape[1], n_rep_boot])
+                omega_sqrt = np.real(sqrtm(self.blp_omega))
+                bootstrap_samples = np.multiply(np.dot(np_basis, np.dot(omega_sqrt, normal_samples)).T, (1.0 / blp_se))
+            else:
+                bootstrap_samples = np.full((basis.shape[0], self.n_rep, n_rep_boot), np.nan)
+                for i_rep in range(self.n_rep):
+                    normal_samples = np.random.normal(size=[basis.shape[1], n_rep_boot])
+                    omega_sqrt = np.real(sqrtm(self._blp_omega[:, :, i_rep]))
+                    bootstrap_samples[:, i_rep, :] = np.dot(np_basis, np.dot(omega_sqrt, normal_samples))
+
+                # aggregate the draws over repetitions according to the median aggregation rule
+                bootstrap_samples = np.divide(np.median(bootstrap_samples, axis=1), blp_se.reshape(-1, 1))
 
             max_t_stat = np.quantile(np.max(np.abs(bootstrap_samples), axis=0), q=level)
 
@@ -243,3 +350,18 @@ class DoubleMLBLP:
             df_ci.index = gate_names
 
         return df_ci
+
+    def _predict_and_aggregate(self, basis):
+        np_basis = basis.to_numpy()
+        n_obs_basis = basis.shape[0]
+
+        all_g_hat = np.full((n_obs_basis, self.n_rep), np.nan)
+        all_blp_se = np.full((n_obs_basis, self.n_rep), np.nan)
+        for i_rep in range(self.n_rep):
+            all_g_hat[:, i_rep] = np.asarray(self._blp_model[i_rep].predict(basis))
+            omega_rep = self._blp_omega[:, :, i_rep]
+            all_blp_se[:, i_rep] = np.sqrt((np.dot(np_basis, omega_rep) * np_basis).sum(axis=1))
+
+        g_hat, blp_se = _aggregate_coefs_and_ses(all_g_hat, all_blp_se)
+
+        return g_hat, blp_se, all_g_hat, all_blp_se

--- a/doubleml/utils/blp.py
+++ b/doubleml/utils/blp.py
@@ -291,7 +291,11 @@ class DoubleMLBLP:
                     ).T
                 else:
                     critical_value = norm.ppf(1 - alpha / 2)
-                    ci = np.vstack((self.coef - critical_value * self.se, self.coef, self.coef + critical_value * self.se)).T
+                    all_ci_lower = self.all_coef - critical_value * self.all_se
+                    all_ci_upper = self.all_coef + critical_value * self.all_se
+                    ci_lower = np.median(all_ci_lower, axis=1)
+                    ci_upper = np.median(all_ci_upper, axis=1)
+                    ci = np.vstack((ci_lower, self.coef, ci_upper)).T
                 df_ci = pd.DataFrame(
                     ci,
                     columns=["{:.1f} %".format(alpha / 2 * 100), "effect", "{:.1f} %".format((1 - alpha / 2) * 100)],

--- a/doubleml/utils/tests/test_blp.py
+++ b/doubleml/utils/tests/test_blp.py
@@ -6,6 +6,8 @@ import pytest
 
 import doubleml as dml
 
+from doubleml.utils._estimation import _aggregate_coefs_and_ses
+
 from ._utils_blp_manual import blp_confint, fit_blp
 
 
@@ -127,6 +129,35 @@ def test_dml_blp_defaults():
 
 
 @pytest.mark.ci
+def test_dml_blp_multi_rep():
+    n = 50
+    n_rep = 3
+    np.random.seed(42)
+    random_basis = pd.DataFrame(np.random.normal(0, 1, size=(n, 3)))
+    random_signal = np.random.normal(0, 1, size=(n, n_rep))
+
+    blp = dml.DoubleMLBLP(random_signal, random_basis)
+    blp.fit()
+
+    expected_coef, expected_se = _aggregate_coefs_and_ses(blp.all_coef, blp.all_se)
+
+    assert blp.n_rep == n_rep
+    assert blp.all_coef.shape == (random_basis.shape[1], n_rep)
+    assert blp.all_se.shape == (random_basis.shape[1], n_rep)
+    assert blp.coef.shape == (random_basis.shape[1],)
+    assert blp.se.shape == (random_basis.shape[1],)
+    assert blp.blp_omega.shape == (random_basis.shape[1], random_basis.shape[1], n_rep)
+
+    assert np.allclose(blp.coef, expected_coef, rtol=1e-9, atol=1e-4)
+    assert np.allclose(blp.se, expected_se, rtol=1e-9, atol=1e-4)
+
+    ci = blp.confint(random_basis)
+    assert isinstance(ci, pd.DataFrame)
+    assert ci.shape[0] == n
+    assert isinstance(blp.summary, pd.DataFrame)
+
+
+@pytest.mark.ci
 def test_doubleml_exception_blp():
     random_basis = pd.DataFrame(np.random.normal(0, 1, size=(2, 3)))
     signal = np.array([1, 2])
@@ -134,9 +165,9 @@ def test_doubleml_exception_blp():
     msg = "The signal must be of np.ndarray type. Signal of type <class 'int'> was passed."
     with pytest.raises(TypeError, match=msg):
         dml.DoubleMLBLP(orth_signal=1, basis=random_basis)
-    msg = "The signal must be of one dimensional. Signal of dimensions 2 was passed."
+    msg = "The signal must be one- or two-dimensional. Signal of dimensions 3 was passed."
     with pytest.raises(ValueError, match=msg):
-        dml.DoubleMLBLP(orth_signal=np.array([[1], [2]]), basis=random_basis)
+        dml.DoubleMLBLP(orth_signal=np.array([[[1]], [[2]]]), basis=random_basis)
     msg = "The basis must be of DataFrame type. Basis of type <class 'int'> was passed."
     with pytest.raises(TypeError, match=msg):
         dml.DoubleMLBLP(orth_signal=signal, basis=1)

--- a/doubleml/utils/tests/test_blp.py
+++ b/doubleml/utils/tests/test_blp.py
@@ -3,10 +3,8 @@ import copy
 import numpy as np
 import pandas as pd
 import pytest
-from scipy.stats import norm
 
 import doubleml as dml
-from doubleml.utils._estimation import _aggregate_coefs_and_ses
 
 from ._utils_blp_manual import blp_confint, fit_blp
 
@@ -31,43 +29,64 @@ def use_t(request):
     return request.param
 
 
+@pytest.fixture(scope="module", params=[1, 3])
+def n_rep(request):
+    return request.param
+
+
 @pytest.fixture(scope="module")
-def dml_blp_fixture(ci_joint, ci_level, cov_type, use_t):
+def dml_blp_fixture(ci_joint, ci_level, cov_type, use_t, n_rep):
     n = 50
     kwargs = {"cov_type": cov_type, "use_t": use_t}
 
     np.random.seed(42)
     random_basis = pd.DataFrame(np.random.normal(0, 1, size=(n, 3)))
-    random_signal = np.random.normal(0, 1, size=(n,))
+    random_signal = np.random.normal(0, 1, size=(n, n_rep))
 
     blp = dml.DoubleMLBLP(random_signal, random_basis)
 
     blp_obj = copy.copy(blp)
     blp.fit(**kwargs)
-    blp_manual = fit_blp(random_signal, random_basis, **kwargs)
+    blp_manual = []
+    for i in range(n_rep):
+        blp_manual.append(fit_blp(random_signal[:, i], random_basis, **kwargs))
 
     np.random.seed(42)
     ci_1 = blp.confint(random_basis, joint=ci_joint, level=ci_level, n_rep_boot=1000)
     np.random.seed(42)
     ci_2 = blp.confint(joint=ci_joint, level=ci_level, n_rep_boot=1000)
-    expected_ci_2 = np.vstack(
-        (
-            blp.blp_model.conf_int(alpha=(1 - ci_level))[0],
-            blp.blp_model.params,
-            blp.blp_model.conf_int(alpha=(1 - ci_level))[1],
+    expected_ci_2 = []
+    for i in range(n_rep):
+        expected_ci_2.append(
+            np.vstack(
+                (
+                    blp.blp_model[i].conf_int(alpha=(1 - ci_level))[0],
+                    blp.blp_model[i].params,
+                    blp.blp_model[i].conf_int(alpha=(1 - ci_level))[1],
+                )
+            ).T
         )
-    ).T
+    expected_ci_2 = np.median(np.array(expected_ci_2), axis=0)
 
     np.random.seed(42)
-    ci_manual = blp_confint(blp_manual, random_basis, joint=ci_joint, level=ci_level, n_rep_boot=1000)
+    ci_manual = []
+    for i in range(n_rep):
+        ci_manual.append(blp_confint(blp_manual[i], random_basis, joint=ci_joint, level=ci_level, n_rep_boot=1000))
+    ci_manual = np.median(np.array([ci_manual[i].to_numpy() for i in range(n_rep)]), axis=0)
+
+    coef_manual = np.median(np.array([blp_manual[i].params for i in range(n_rep)]), axis=0)
+    omega_manual = np.transpose(np.array([blp_manual[i].cov_params().to_numpy() for i in range(n_rep)]), (1, 2, 0))
+
+    fittedvalues_manual = np.array([blp_manual[i].fittedvalues for i in range(n_rep)])
+    fittedvalues = np.array([blp.blp_model[i].fittedvalues for i in range(n_rep)])
 
     res_dict = {
-        "coef": blp.blp_model.params,
-        "coef_manual": blp_manual.params,
-        "values": blp.blp_model.fittedvalues,
-        "values_manual": blp_manual.fittedvalues,
+        "coef": blp.coef,
+        "coef_manual": coef_manual,
+        "values": fittedvalues,
+        "values_manual": fittedvalues_manual,
         "omega": blp.blp_omega,
-        "omega_manual": blp_manual.cov_params().to_numpy(),
+        "omega_manual": omega_manual,
         "basis": blp.basis,
         "signal": blp.orth_signal,
         "ci_1": ci_1,
@@ -123,47 +142,9 @@ def test_dml_blp_defaults():
     blp = dml.DoubleMLBLP(random_signal, random_basis)
     blp.fit()
 
-    assert np.allclose(blp.blp_omega, blp.blp_model.cov_HC0, rtol=1e-9, atol=1e-4)
+    assert np.allclose(blp.blp_omega[:, :, 0], blp.blp_model[0].cov_HC0, rtol=1e-9, atol=1e-4)
 
     assert blp._is_gate is False
-
-
-@pytest.mark.ci
-def test_dml_blp_multi_rep():
-    n = 50
-    n_rep = 3
-    level = 0.9
-    np.random.seed(42)
-    random_basis = pd.DataFrame(np.random.normal(0, 1, size=(n, 3)))
-    random_signal = np.random.normal(0, 1, size=(n, n_rep))
-
-    blp = dml.DoubleMLBLP(random_signal, random_basis)
-    blp.fit()
-
-    expected_coef, expected_se = _aggregate_coefs_and_ses(blp.all_coef, blp.all_se)
-
-    assert blp.n_rep == n_rep
-    assert blp.all_coef.shape == (random_basis.shape[1], n_rep)
-    assert blp.all_se.shape == (random_basis.shape[1], n_rep)
-    assert blp.coef.shape == (random_basis.shape[1],)
-    assert blp.se.shape == (random_basis.shape[1],)
-    assert blp.blp_omega.shape == (random_basis.shape[1], random_basis.shape[1], n_rep)
-
-    assert np.allclose(blp.coef, expected_coef, rtol=1e-9, atol=1e-4)
-    assert np.allclose(blp.se, expected_se, rtol=1e-9, atol=1e-4)
-
-    ci = blp.confint(random_basis)
-    assert isinstance(ci, pd.DataFrame)
-    assert ci.shape[0] == n
-
-    ci_coef = blp.confint(level=level)
-    critical_value = norm.ppf(1 - (1 - level) / 2)
-    expected_ci_lower = blp.coef - critical_value * blp.se
-    expected_ci_upper = blp.coef + critical_value * blp.se
-    expected_ci_coef = np.vstack((expected_ci_lower, blp.coef, expected_ci_upper)).T
-    assert np.allclose(ci_coef.to_numpy(), expected_ci_coef, rtol=1e-9, atol=1e-4)
-
-    assert isinstance(blp.summary, pd.DataFrame)
 
 
 @pytest.mark.ci

--- a/doubleml/utils/tests/test_blp.py
+++ b/doubleml/utils/tests/test_blp.py
@@ -3,6 +3,7 @@ import copy
 import numpy as np
 import pandas as pd
 import pytest
+from scipy.stats import norm
 
 import doubleml as dml
 from doubleml.utils._estimation import _aggregate_coefs_and_ses
@@ -153,6 +154,14 @@ def test_dml_blp_multi_rep():
     ci = blp.confint(random_basis)
     assert isinstance(ci, pd.DataFrame)
     assert ci.shape[0] == n
+
+    ci_coef = blp.confint(level=0.9)
+    critical_value = norm.ppf(1 - (1 - 0.9) / 2)
+    expected_ci_lower = np.median(blp.all_coef - critical_value * blp.all_se, axis=1)
+    expected_ci_upper = np.median(blp.all_coef + critical_value * blp.all_se, axis=1)
+    expected_ci_coef = np.vstack((expected_ci_lower, blp.coef, expected_ci_upper)).T
+    assert np.allclose(ci_coef.to_numpy(), expected_ci_coef, rtol=1e-9, atol=1e-4)
+
     assert isinstance(blp.summary, pd.DataFrame)
 
 

--- a/doubleml/utils/tests/test_blp.py
+++ b/doubleml/utils/tests/test_blp.py
@@ -132,6 +132,7 @@ def test_dml_blp_defaults():
 def test_dml_blp_multi_rep():
     n = 50
     n_rep = 3
+    level = 0.9
     np.random.seed(42)
     random_basis = pd.DataFrame(np.random.normal(0, 1, size=(n, 3)))
     random_signal = np.random.normal(0, 1, size=(n, n_rep))
@@ -155,10 +156,10 @@ def test_dml_blp_multi_rep():
     assert isinstance(ci, pd.DataFrame)
     assert ci.shape[0] == n
 
-    ci_coef = blp.confint(level=0.9)
-    critical_value = norm.ppf(1 - (1 - 0.9) / 2)
-    expected_ci_lower = np.median(blp.all_coef - critical_value * blp.all_se, axis=1)
-    expected_ci_upper = np.median(blp.all_coef + critical_value * blp.all_se, axis=1)
+    ci_coef = blp.confint(level=level)
+    critical_value = norm.ppf(1 - (1 - level) / 2)
+    expected_ci_lower = blp.coef - critical_value * blp.se
+    expected_ci_upper = blp.coef + critical_value * blp.se
     expected_ci_coef = np.vstack((expected_ci_lower, blp.coef, expected_ci_upper)).T
     assert np.allclose(ci_coef.to_numpy(), expected_ci_coef, rtol=1e-9, atol=1e-4)
 

--- a/doubleml/utils/tests/test_blp.py
+++ b/doubleml/utils/tests/test_blp.py
@@ -140,6 +140,7 @@ def test_dml_blp_defaults():
     random_signal = np.random.normal(0, 1, size=(n,))
 
     blp = dml.DoubleMLBLP(random_signal, random_basis)
+    assert blp.blp_omega is None
     blp.fit()
 
     assert np.allclose(blp.blp_omega[:, :, 0], blp.blp_model[0].cov_HC0, rtol=1e-9, atol=1e-4)
@@ -151,6 +152,7 @@ def test_dml_blp_defaults():
 def test_doubleml_exception_blp():
     random_basis = pd.DataFrame(np.random.normal(0, 1, size=(2, 3)))
     signal = np.array([1, 2])
+    signal_mismatch = np.array([1, 2, 3])
 
     msg = "The signal must be of np.ndarray type. Signal of type <class 'int'> was passed."
     with pytest.raises(TypeError, match=msg):
@@ -161,6 +163,9 @@ def test_doubleml_exception_blp():
     msg = "The basis must be of DataFrame type. Basis of type <class 'int'> was passed."
     with pytest.raises(TypeError, match=msg):
         dml.DoubleMLBLP(orth_signal=signal, basis=1)
+    msg = "The number of observations in signal and basis does not match. Got 3 and 2."
+    with pytest.raises(ValueError, match=msg):
+        dml.DoubleMLBLP(orth_signal=signal_mismatch, basis=random_basis)
     msg = "Invalid pd.DataFrame: Contains duplicate column names."
     with pytest.raises(ValueError, match=msg):
         dml.DoubleMLBLP(orth_signal=signal, basis=pd.DataFrame(np.array([[1, 2], [4, 5]]), columns=["a_1", "a_1"]))
@@ -186,6 +191,9 @@ def test_doubleml_exception_blp():
     msg = "The number of bootstrap replications must be positive. 0 was passed."
     with pytest.raises(ValueError, match=msg):
         dml_blp_confint.confint(random_basis, n_rep_boot=0)
+    msg = "The basis must be of DataFrame type. Basis of type <class 'int'> was passed."
+    with pytest.raises(TypeError, match=msg):
+        dml_blp_confint.confint(basis=1)
     msg = "Invalid basis: DataFrame has to have the exact same number and ordering of columns."
     with pytest.raises(ValueError, match=msg):
         dml_blp_confint.confint(basis=pd.DataFrame(np.array([[1], [4]]), columns=["a_1"]))

--- a/doubleml/utils/tests/test_blp.py
+++ b/doubleml/utils/tests/test_blp.py
@@ -52,9 +52,9 @@ def dml_blp_fixture(ci_joint, ci_level, cov_type, use_t):
     ci_2 = blp.confint(joint=ci_joint, level=ci_level, n_rep_boot=1000)
     expected_ci_2 = np.vstack(
         (
-            blp.blp_model.conf_int(alpha=(1 - ci_level) / 2)[0],
+            blp.blp_model.conf_int(alpha=(1 - ci_level))[0],
             blp.blp_model.params,
-            blp.blp_model.conf_int(alpha=(1 - ci_level) / 2)[1],
+            blp.blp_model.conf_int(alpha=(1 - ci_level))[1],
         )
     ).T
 

--- a/doubleml/utils/tests/test_blp.py
+++ b/doubleml/utils/tests/test_blp.py
@@ -5,7 +5,6 @@ import pandas as pd
 import pytest
 
 import doubleml as dml
-
 from doubleml.utils._estimation import _aggregate_coefs_and_ses
 
 from ._utils_blp_manual import blp_confint, fit_blp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,3 +147,7 @@ color_output = true
 
 # Handle third-party libraries:
 ignore_missing_imports = true
+
+# Ignore asserts in all test files
+[tool.bandit.assert_used]
+skips = ["tests/*", "*/tests/*"]


### PR DESCRIPTION
### Description
We modify the DoubleMLBLP class to handle multiple orthogonal basis from a repeated cross-fitting procedure. We modify IRM; PLR and APO to allow CATEs and GATEs when n_rep>1.

### Reference to Issues or PRs
Feature Request #259

### PR Checklist
Please fill out this PR checklist (see our [contributing guidelines](https://github.com/DoubleML/doubleml-for-py/blob/main/CONTRIBUTING.md#checklist-for-pull-requests-pr) for details).

- [x] The title of the pull request summarizes the changes made.
- [x] The PR contains a detailed description of all changes and additions.
- [x] References to related issues or PRs are added.
- [x] The code passes all (unit) tests.
- [x] Enhancements or new feature are equipped with unit tests.
- [x] The changes adhere to the PEP8 standards.
