### PR TITLE
Fix: Enhance sample weight support checks and add corresponding tests

### DIFF
--- a/doubleml/utils/_checks.py
+++ b/doubleml/utils/_checks.py
@@ -1,3 +1,4 @@
+import inspect
 import warnings
 
 import numpy as np
@@ -514,7 +515,9 @@ def _check_sample_splitting(all_smpls, all_smpls_cluster, dml_data, is_cluster_d
 
 
 def _check_supports_sample_weights(learner, learner_name):
-    if not has_fit_parameter(learner, "sample_weight"):
+    has_explicit = has_fit_parameter(learner, "sample_weight")
+    has_var_keyword = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in inspect.signature(learner.fit).parameters.values())
+    if not (has_explicit or has_var_keyword):
         raise ValueError(
             f"The {learner_name} learner {str(learner)} does not support sample weights. "
             "Please choose a learner that supports sample weights."

--- a/doubleml/utils/tests/test_global_learners.py
+++ b/doubleml/utils/tests/test_global_learners.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-from sklearn import __version__ as sklearn_version
 from sklearn.base import clone
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor, StackingClassifier, StackingRegressor
 from sklearn.linear_model import LinearRegression, LogisticRegression
@@ -8,14 +7,6 @@ from sklearn.model_selection import KFold
 from sklearn.utils.estimator_checks import check_estimator
 
 from doubleml.utils import GlobalClassifier, GlobalRegressor
-
-
-def parse_version(version):
-    return tuple(map(int, version.split(".")[:2]))
-
-
-# TODO(0.11) can be removed if the sklearn dependency is bumped to 1.6.0
-sklearn_post_1_6 = parse_version(sklearn_version) >= (1, 6)
 
 
 @pytest.fixture(
@@ -35,32 +26,24 @@ def classifier(request):
 
 @pytest.mark.ci
 def test_global_regressor(regressor):
-    if sklearn_post_1_6:
-        check_estimator(
-            estimator=GlobalRegressor(base_estimator=regressor),
-            expected_failed_checks={
-                "check_sample_weight_equivalence_on_dense_data": "weights are ignored",
-                "check_estimators_nan_inf": "allowed for some estimators",
-            },
-        )
-    else:
-        # TODO(0.11) can be removed if the sklearn dependency is bumped to 1.6.0
-        pytest.skip("sklearn version is too old for this test")
+    check_estimator(
+        estimator=GlobalRegressor(base_estimator=regressor),
+        expected_failed_checks={
+            "check_sample_weight_equivalence_on_dense_data": "weights are ignored",
+            "check_estimators_nan_inf": "allowed for some estimators",
+        },
+    )
 
 
 @pytest.mark.ci
 def test_global_classifier(classifier):
-    if sklearn_post_1_6:
-        check_estimator(
-            estimator=GlobalClassifier(base_estimator=classifier),
-            expected_failed_checks={
-                "check_sample_weight_equivalence_on_dense_data": "weights are ignored",
-                "check_estimators_nan_inf": "allowed for some estimators",
-            },
-        )
-    else:
-        # TODO(0.11) can be removed if the sklearn dependency is bumped to 1.6.0
-        pytest.skip("sklearn version is too old for this test")
+    check_estimator(
+        estimator=GlobalClassifier(base_estimator=classifier),
+        expected_failed_checks={
+            "check_sample_weight_equivalence_on_dense_data": "weights are ignored",
+            "check_estimators_nan_inf": "allowed for some estimators",
+        },
+    )
 
 
 @pytest.fixture(scope="module")

--- a/doubleml/utils/tests/test_support_sample_weights.py
+++ b/doubleml/utils/tests/test_support_sample_weights.py
@@ -1,0 +1,63 @@
+import re
+
+import pytest
+from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor, StackingClassifier, StackingRegressor
+from sklearn.linear_model import LinearRegression, LogisticRegression
+from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
+
+from doubleml.utils import GlobalClassifier, GlobalRegressor
+from doubleml.utils._checks import _check_supports_sample_weights
+
+reg_estimators = [
+    ("lr local", LinearRegression()),
+    ("rf local", RandomForestRegressor(n_estimators=10, random_state=42)),
+    ("lr global", GlobalRegressor(base_estimator=LinearRegression())),
+    ("rf global", GlobalRegressor(base_estimator=RandomForestRegressor(n_estimators=10, random_state=42))),
+]
+
+class_estimators = [
+    ("lr local", LogisticRegression(random_state=42)),
+    ("rf local", RandomForestClassifier(n_estimators=10, random_state=42)),
+    ("lr global", GlobalClassifier(base_estimator=LogisticRegression(random_state=42))),
+    ("rf global", GlobalClassifier(base_estimator=RandomForestClassifier(n_estimators=10, random_state=42))),
+]
+
+ml_g = StackingRegressor(
+    estimators=reg_estimators,
+    final_estimator=LinearRegression(),
+)
+
+ml_m = StackingClassifier(
+    estimators=class_estimators,
+    final_estimator=LogisticRegression(random_state=42),
+)
+
+
+@pytest.mark.ci
+@pytest.mark.parametrize(
+    "learner, learner_name",
+    [(learner, "ml_g") for _, learner in reg_estimators]
+    + [(learner, "ml_m") for _, learner in class_estimators]
+    + [(ml_g, "ml_g"), (ml_m, "ml_m")],
+)
+def test_check_supports_sample_weights_valid(learner, learner_name):
+    # explicit sample_weight parameter (base learners + Global wrappers)
+    # or **fit_params catch-all (StackingRegressor/StackingClassifier)
+    _check_supports_sample_weights(learner, learner_name)
+
+
+@pytest.mark.ci
+@pytest.mark.parametrize(
+    "learner, learner_name",
+    [
+        (KNeighborsRegressor(), "ml_g"),
+        (KNeighborsClassifier(), "ml_m"),
+    ],
+)
+def test_check_supports_sample_weights_invalid(learner, learner_name):
+    msg = re.escape(
+        f"The {learner_name} learner {str(learner)} does not support sample weights. "
+        "Please choose a learner that supports sample weights."
+    )
+    with pytest.raises(ValueError, match=msg):
+        _check_supports_sample_weights(learner, learner_name)


### PR DESCRIPTION
With the current versions of sklearn, meta-learners such as `StackingRegressor` where not useable for `RDFlex` as `_check_supports_sample_weights` was failing.

Now also allows passes the checks if `**kwargs` are allowed, see [StackingRegressor.fit()](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.StackingRegressor.html#sklearn.ensemble.StackingRegressor.fit).


### PR Checklist
Please fill out this PR checklist (see our [contributing guidelines](https://github.com/DoubleML/doubleml-for-py/blob/main/CONTRIBUTING.md#checklist-for-pull-requests-pr) for details).

- [x] The title of the pull request summarizes the changes made.
- [x] The PR contains a detailed description of all changes and additions.
- [x] References to related issues or PRs are added.
- [x] The code passes all (unit) tests.
- [x] Enhancements or new feature are equipped with unit tests.
- [x] The changes adhere to the PEP8 standards.
