### PR TITLE
Remove deprecated trimming inputs and update workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,15 +27,15 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/deploy_pkg.yml
+++ b/.github/workflows/deploy_pkg.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Download built package
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: DoubleML-pkg
           path: dist/
@@ -98,7 +98,7 @@ jobs:
 
     steps:
       - name: Download built package
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: DoubleML-pkg
           path: dist/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -86,7 +86,7 @@ jobs:
       if: |
         matrix.config.os == 'ubuntu-latest' &&
         matrix.config.python-version == '3.12'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         fail_ci_if_error: false
         files: ./coverage.xml

--- a/doubleml/did/did_binary.py
+++ b/doubleml/did/did_binary.py
@@ -27,7 +27,6 @@ from doubleml.utils._tune_optuna import _dml_tune_optuna
 from doubleml.utils.propensity_score_processing import PSProcessorConfig, init_ps_processor
 
 
-# TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
 class DoubleMLDIDBinary(LinearScoreMixin, DoubleML):
     """Double machine learning for difference-in-differences models with panel data (binary setting in terms of group and time
      combinations).
@@ -84,14 +83,6 @@ class DoubleMLDIDBinary(LinearScoreMixin, DoubleML):
         Indicates whether to use a slightly different normalization from Sant'Anna and Zhao (2020).
         Default is ``True``.
 
-    trimming_rule : str, optional, deprecated
-        (DEPRECATED) A str (``'truncate'`` is the only choice) specifying the trimming approach.
-        Use `ps_processor_config` instead. Will be removed in a future version.
-
-    trimming_threshold : float, optional, deprecated
-        (DEPRECATED) The threshold used for trimming.
-        Use `ps_processor_config` instead. Will be removed in a future version.
-
     ps_processor_config : PSProcessorConfig, optional
         Configuration for propensity score processing (clipping, calibration, etc.).
 
@@ -119,8 +110,6 @@ class DoubleMLDIDBinary(LinearScoreMixin, DoubleML):
         n_rep=1,
         score="observational",
         in_sample_normalization=True,
-        trimming_rule="truncate",  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        trimming_threshold=1e-2,  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
         ps_processor_config: Optional[PSProcessorConfig] = None,
         draw_sample_splitting=True,
         print_periods=False,
@@ -237,12 +226,7 @@ class DoubleMLDIDBinary(LinearScoreMixin, DoubleML):
             self._predict_method["ml_m"] = "predict_proba"
         self._initialize_ml_nuisance_params()
 
-        # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        self._ps_processor_config, self._ps_processor = init_ps_processor(
-            ps_processor_config, trimming_rule, trimming_threshold
-        )
-        self._trimming_rule = trimming_rule
-        self._trimming_threshold = self._ps_processor.clipping_threshold
+        self._ps_processor_config, self._ps_processor = init_ps_processor(ps_processor_config)
 
         self._sensitivity_implemented = True
         self._external_predictions_implemented = True
@@ -342,31 +326,6 @@ class DoubleMLDIDBinary(LinearScoreMixin, DoubleML):
         Propensity score processor.
         """
         return self._ps_processor
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_rule(self):
-        """
-        Specifies the used trimming rule.
-        """
-        warnings.warn(
-            "'trimming_rule' is deprecated and will be removed in a future version. ", DeprecationWarning, stacklevel=2
-        )
-        return self._trimming_rule
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_threshold(self):
-        """
-        Specifies the used trimming threshold.
-        """
-        warnings.warn(
-            "'trimming_threshold' is deprecated and will be removed in a future version. "
-            "Use 'ps_processor_config.clipping_threshold' or 'ps_processor.clipping_threshold' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._ps_processor.clipping_threshold
 
     @property
     def n_obs_subset(self):

--- a/doubleml/did/did_cs_binary.py
+++ b/doubleml/did/did_cs_binary.py
@@ -27,7 +27,6 @@ from doubleml.utils._tune_optuna import _dml_tune_optuna
 from doubleml.utils.propensity_score_processing import PSProcessorConfig, init_ps_processor
 
 
-# TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
 class DoubleMLDIDCSBinary(LinearScoreMixin, DoubleML):
     """Double machine learning for difference-in-differences models with repeated cross sections
     (binary setting in terms of group and time combinations).
@@ -84,14 +83,6 @@ class DoubleMLDIDCSBinary(LinearScoreMixin, DoubleML):
         Indicates whether to use a slightly different normalization from Sant'Anna and Zhao (2020).
         Default is ``True``.
 
-    trimming_rule : str, optional, deprecated
-        (DEPRECATED) A str (``'truncate'`` is the only choice) specifying the trimming approach.
-        Use `ps_processor_config` instead. Will be removed in a future version.
-
-    trimming_threshold : float, optional, deprecated
-        (DEPRECATED) The threshold used for trimming.
-        Use `ps_processor_config` instead. Will be removed in a future version.
-
     ps_processor_config : PSProcessorConfig, optional
         Configuration for propensity score processing (clipping, calibration, etc.).
 
@@ -119,8 +110,6 @@ class DoubleMLDIDCSBinary(LinearScoreMixin, DoubleML):
         n_rep=1,
         score="observational",
         in_sample_normalization=True,
-        trimming_rule="truncate",  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        trimming_threshold=1e-2,  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
         ps_processor_config: Optional[PSProcessorConfig] = None,
         draw_sample_splitting=True,
         print_periods=False,
@@ -226,12 +215,7 @@ class DoubleMLDIDCSBinary(LinearScoreMixin, DoubleML):
             self._predict_method["ml_m"] = "predict_proba"
         self._initialize_ml_nuisance_params()
 
-        # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        self._ps_processor_config, self._ps_processor = init_ps_processor(
-            ps_processor_config, trimming_rule, trimming_threshold
-        )
-        self._trimming_rule = trimming_rule
-        self._trimming_threshold = self._ps_processor.clipping_threshold
+        self._ps_processor_config, self._ps_processor = init_ps_processor(ps_processor_config)
 
         self._sensitivity_implemented = True
         self._external_predictions_implemented = True
@@ -333,31 +317,6 @@ class DoubleMLDIDCSBinary(LinearScoreMixin, DoubleML):
         Propensity score processor.
         """
         return self._ps_processor
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_rule(self):
-        """
-        Specifies the used trimming rule.
-        """
-        warnings.warn(
-            "'trimming_rule' is deprecated and will be removed in a future version. ", DeprecationWarning, stacklevel=2
-        )
-        return self._trimming_rule
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_threshold(self):
-        """
-        Specifies the used trimming threshold.
-        """
-        warnings.warn(
-            "'trimming_threshold' is deprecated and will be removed in a future version. "
-            "Use 'ps_processor_config.clipping_threshold' or 'ps_processor.clipping_threshold' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._ps_processor.clipping_threshold
 
     @property
     def n_obs_subset(self):

--- a/doubleml/did/did_multi.py
+++ b/doubleml/did/did_multi.py
@@ -41,7 +41,6 @@ from doubleml.utils.gain_statistics import gain_statistics
 from doubleml.utils.propensity_score_processing import PSProcessorConfig, init_ps_processor
 
 
-# TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
 class DoubleMLDIDMulti:
     """Double machine learning for multi-period difference-in-differences models.
 
@@ -95,18 +94,6 @@ class DoubleMLDIDMulti:
     in_sample_normalization : bool
         Indicates whether to use in-sample normalization of weights.
         Default is ``True``.
-
-    trimming_rule : str
-        A str (``'truncate'`` is the only choice) specifying the trimming approach.
-        Default is ``'truncate'``.
-
-    trimming_rule : str, optional, deprecated
-        (DEPRECATED) A str (``'truncate'`` is the only choice) specifying the trimming approach.
-        Use `ps_processor_config` instead. Will be removed in a future version.
-
-    trimming_threshold : float, optional, deprecated
-        (DEPRECATED) The threshold used for trimming.
-        Use `ps_processor_config` instead. Will be removed in a future version.
 
     ps_processor_config : PSProcessorConfig, optional
         Configuration for propensity score processing (clipping, calibration, etc.).
@@ -172,8 +159,6 @@ class DoubleMLDIDMulti:
         score="observational",
         panel=True,
         in_sample_normalization=True,
-        trimming_rule="truncate",  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        trimming_threshold=1e-2,  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
         ps_processor_config: Optional[PSProcessorConfig] = None,
         draw_sample_splitting=True,
         print_periods=False,
@@ -222,12 +207,7 @@ class DoubleMLDIDMulti:
         # initialize framework which is constructed after the fit method is called
         self._framework = None
 
-        # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        self._ps_processor_config, self._ps_processor = init_ps_processor(
-            ps_processor_config, trimming_rule, trimming_threshold
-        )
-        self._trimming_rule = trimming_rule
-        self._trimming_threshold = self._ps_processor.clipping_threshold
+        self._ps_processor_config, self._ps_processor = init_ps_processor(ps_processor_config)
 
         ml_g_is_classifier = DoubleML._check_learner(ml_g, "ml_g", regressor=True, classifier=True)
         if self.score == "observational":
@@ -401,31 +381,6 @@ class DoubleMLDIDMulti:
         Propensity score processor.
         """
         return self._ps_processor
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_rule(self):
-        """
-        Specifies the used trimming rule.
-        """
-        warnings.warn(
-            "'trimming_rule' is deprecated and will be removed in a future version. ", DeprecationWarning, stacklevel=2
-        )
-        return self._trimming_rule
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_threshold(self):
-        """
-        Specifies the used trimming threshold.
-        """
-        warnings.warn(
-            "'trimming_threshold' is deprecated and will be removed in a future version. "
-            "Use 'ps_processor_config.clipping_threshold' or 'ps_processor.clipping_threshold' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._ps_processor.clipping_threshold
 
     @property
     def n_folds(self):

--- a/doubleml/did/tests/test_return_types.py
+++ b/doubleml/did/tests/test_return_types.py
@@ -12,6 +12,7 @@ from doubleml.utils._check_return_types import (
     check_basic_return_types,
     check_sensitivity_return_types,
 )
+from doubleml.utils.propensity_score_processing import PSProcessor, PSProcessorConfig
 
 # Test constants
 N_OBS = 200
@@ -163,10 +164,8 @@ def test_panel_return_types(dml_obj, cls):
 
     # propensity score properties
     assert isinstance(dml_obj.in_sample_normalization, bool)
-    assert isinstance(dml_obj.trimming_rule, str)
-    assert dml_obj.trimming_rule in ["truncate"]
-    assert isinstance(dml_obj.trimming_threshold, (float, np.floating))
-    assert 0 <= dml_obj.trimming_threshold <= 0.5
+    assert isinstance(dml_obj.ps_processor_config, PSProcessorConfig)
+    assert isinstance(dml_obj.ps_processor, PSProcessor)
 
     # Test n_obs property
     assert isinstance(dml_obj.n_obs, (int, np.integer))

--- a/doubleml/irm/apo.py
+++ b/doubleml/irm/apo.py
@@ -67,14 +67,6 @@ class DoubleMLAPO(LinearScoreMixin, DoubleML):
         Indicates whether the inverse probability weights are normalized.
         Default is ``False``.
 
-    trimming_rule : str, optional, deprecated
-        (DEPRECATED) A str (``'truncate'`` is the only choice) specifying the trimming approach.
-        Use `ps_processor_config` instead. Will be removed in a future version.
-
-    trimming_threshold : float, optional, deprecated
-        (DEPRECATED) The threshold used for trimming.
-        Use `ps_processor_config` instead. Will be removed in a future version.
-
     ps_processor_config : PSProcessorConfig, optional
         Configuration for propensity score processing (clipping, calibration, etc.).
 
@@ -95,8 +87,6 @@ class DoubleMLAPO(LinearScoreMixin, DoubleML):
         score="APO",
         weights=None,
         normalize_ipw=False,
-        trimming_rule="truncate",  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        trimming_threshold=1e-2,  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
         ps_processor_config: Optional[PSProcessorConfig] = None,
         draw_sample_splitting=True,
     ):
@@ -137,12 +127,7 @@ class DoubleMLAPO(LinearScoreMixin, DoubleML):
                 "Normalization indicator has to be boolean. " + f"Object of type {str(type(self.normalize_ipw))} passed."
             )
 
-        # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        self._ps_processor_config, self._ps_processor = init_ps_processor(
-            ps_processor_config, trimming_rule, trimming_threshold
-        )
-        self._trimming_rule = trimming_rule
-        self._trimming_threshold = self._ps_processor.clipping_threshold
+        self._ps_processor_config, self._ps_processor = init_ps_processor(ps_processor_config)
 
         self._sensitivity_implemented = True
         self._external_predictions_implemented = True
@@ -185,31 +170,6 @@ class DoubleMLAPO(LinearScoreMixin, DoubleML):
         Propensity score processor.
         """
         return self._ps_processor
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_rule(self):
-        """
-        Specifies the used trimming rule.
-        """
-        warnings.warn(
-            "'trimming_rule' is deprecated and will be removed in a future version. ", DeprecationWarning, stacklevel=2
-        )
-        return self._trimming_rule
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_threshold(self):
-        """
-        Specifies the used trimming threshold.
-        """
-        warnings.warn(
-            "'trimming_threshold' is deprecated and will be removed in a future version. "
-            "Use 'ps_processor_config.clipping_threshold' or 'ps_processor.clipping_threshold' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._ps_processor.clipping_threshold
 
     @property
     def weights(self):

--- a/doubleml/irm/apos.py
+++ b/doubleml/irm/apos.py
@@ -1,5 +1,4 @@
 import copy
-import warnings
 from collections.abc import Iterable
 from typing import Optional
 
@@ -70,14 +69,6 @@ class DoubleMLAPOS(SampleSplittingMixin):
         Indicates whether the inverse probability weights are normalized.
         Default is ``False``.
 
-    trimming_rule : str, optional, deprecated
-        (DEPRECATED) A str (``'truncate'`` is the only choice) specifying the trimming approach.
-        Use ``ps_processor_config`` instead. Will be removed in a future version.
-
-    trimming_threshold : float, optional, deprecated
-        (DEPRECATED) The threshold used for trimming.
-        Use ``ps_processor_config`` instead. Will be removed in a future version.
-
     ps_processor_config : PSProcessorConfig, optional
         Configuration for propensity score processing (clipping, calibration, etc.).
 
@@ -97,8 +88,6 @@ class DoubleMLAPOS(SampleSplittingMixin):
         score="APO",
         weights=None,
         normalize_ipw=False,
-        trimming_rule="truncate",  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        trimming_threshold=1e-2,  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
         ps_processor_config: Optional[PSProcessorConfig] = None,
         draw_sample_splitting=True,
     ):
@@ -125,12 +114,7 @@ class DoubleMLAPOS(SampleSplittingMixin):
         # initialize framework which is constructed after the fit method is called
         self._framework = None
 
-        # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        self._ps_processor_config, self._ps_processor = init_ps_processor(
-            ps_processor_config, trimming_rule, trimming_threshold
-        )
-        self._trimming_rule = trimming_rule
-        self._trimming_threshold = self._ps_processor.clipping_threshold
+        self._ps_processor_config, self._ps_processor = init_ps_processor(ps_processor_config)
 
         if not isinstance(self.normalize_ipw, bool):
             raise TypeError(
@@ -213,31 +197,6 @@ class DoubleMLAPOS(SampleSplittingMixin):
         Propensity score processor.
         """
         return self._ps_processor
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_rule(self):
-        """
-        Specifies the used trimming rule.
-        """
-        warnings.warn(
-            "'trimming_rule' is deprecated and will be removed in a future version. ", DeprecationWarning, stacklevel=2
-        )
-        return self._trimming_rule
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_threshold(self):
-        """
-        Specifies the used trimming threshold.
-        """
-        warnings.warn(
-            "'trimming_threshold' is deprecated and will be removed in a future version. "
-            "Use 'ps_processor_config.clipping_threshold' or 'ps_processor.clipping_threshold' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._ps_processor.clipping_threshold
 
     @property
     def weights(self):

--- a/doubleml/irm/cvar.py
+++ b/doubleml/irm/cvar.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Optional
 
 import numpy as np
@@ -29,7 +28,6 @@ from doubleml.utils._tune_optuna import _dml_tune_optuna
 from doubleml.utils.propensity_score_processing import PSProcessorConfig, init_ps_processor
 
 
-# TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
 class DoubleMLCVAR(LinearScoreMixin, DoubleML):
     """Double machine learning for conditional value at risk for potential outcomes
 
@@ -71,14 +69,6 @@ class DoubleMLCVAR(LinearScoreMixin, DoubleML):
         Indicates whether the inverse probability weights are normalized.
         Default is ``True``.
 
-    trimming_rule : str, optional, deprecated
-        (DEPRECATED) A str (``'truncate'`` is the only choice) specifying the trimming approach.
-        Use `ps_processor_config` instead. Will be removed in a future version.
-
-    trimming_threshold : float, optional, deprecated
-        (DEPRECATED) The threshold used for trimming.
-        Use `ps_processor_config` instead. Will be removed in a future version.
-
     ps_processor_config : PSProcessorConfig, optional
         Configuration for propensity score processing (clipping, calibration, etc.).
 
@@ -115,8 +105,6 @@ class DoubleMLCVAR(LinearScoreMixin, DoubleML):
         n_rep=1,
         score="CVaR",
         normalize_ipw=True,
-        trimming_rule="truncate",  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        trimming_threshold=1e-2,  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
         ps_processor_config: Optional[PSProcessorConfig] = None,
         draw_sample_splitting=True,
     ):
@@ -148,12 +136,7 @@ class DoubleMLCVAR(LinearScoreMixin, DoubleML):
         if draw_sample_splitting:
             self.draw_sample_splitting()
 
-        # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        self._ps_processor_config, self._ps_processor = init_ps_processor(
-            ps_processor_config, trimming_rule, trimming_threshold
-        )
-        self._trimming_rule = trimming_rule
-        self._trimming_threshold = self._ps_processor.clipping_threshold
+        self._ps_processor_config, self._ps_processor = init_ps_processor(ps_processor_config)
 
         _ = self._check_learner(ml_g, "ml_g", regressor=True, classifier=False)
         _ = self._check_learner(ml_m, "ml_m", regressor=False, classifier=True)
@@ -196,31 +179,6 @@ class DoubleMLCVAR(LinearScoreMixin, DoubleML):
         Propensity score processor.
         """
         return self._ps_processor
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_rule(self):
-        """
-        Specifies the used trimming rule.
-        """
-        warnings.warn(
-            "'trimming_rule' is deprecated and will be removed in a future version. ", DeprecationWarning, stacklevel=2
-        )
-        return self._trimming_rule
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_threshold(self):
-        """
-        Specifies the used trimming threshold.
-        """
-        warnings.warn(
-            "'trimming_threshold' is deprecated and will be removed in a future version. "
-            "Use 'ps_processor_config.clipping_threshold' or 'ps_processor.clipping_threshold' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._ps_processor.clipping_threshold
 
     def _compute_ipw_score(self, theta, d, y, prop):
         score = (d == self.treatment) / prop * (y <= theta) - self.quantile

--- a/doubleml/irm/iivm.py
+++ b/doubleml/irm/iivm.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Optional
 
 import numpy as np
@@ -68,14 +67,6 @@ class DoubleMLIIVM(LinearScoreMixin, DoubleML):
         Indicates whether the inverse probability weights are normalized.
         Default is ``False``.
 
-    trimming_rule : str, optional, deprecated
-        (DEPRECATED) A str (``'truncate'`` is the only choice) specifying the trimming approach.
-        Use `ps_processor_config` instead. Will be removed in a future version.
-
-    trimming_threshold : float, optional, deprecated
-        (DEPRECATED) The threshold used for trimming.
-        Use `ps_processor_config` instead. Will be removed in a future version.
-
     ps_processor_config : PSProcessorConfig, optional
         Configuration for propensity score processing (clipping, calibration, etc.).
 
@@ -142,8 +133,6 @@ class DoubleMLIIVM(LinearScoreMixin, DoubleML):
         score="LATE",
         subgroups=None,
         normalize_ipw=False,
-        trimming_rule="truncate",  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        trimming_threshold=1e-2,  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
         ps_processor_config: Optional[PSProcessorConfig] = None,
         draw_sample_splitting=True,
     ):
@@ -181,12 +170,7 @@ class DoubleMLIIVM(LinearScoreMixin, DoubleML):
                 "Normalization indicator has to be boolean. " + f"Object of type {str(type(self.normalize_ipw))} passed."
             )
 
-        # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        self._ps_processor_config, self._ps_processor = init_ps_processor(
-            ps_processor_config, trimming_rule, trimming_threshold
-        )
-        self._trimming_rule = trimming_rule
-        self._trimming_threshold = self._ps_processor.clipping_threshold
+        self._ps_processor_config, self._ps_processor = init_ps_processor(ps_processor_config)
 
         if subgroups is None:
             # this is the default for subgroups; via None to prevent a mutable default argument
@@ -238,31 +222,6 @@ class DoubleMLIIVM(LinearScoreMixin, DoubleML):
         Propensity score processor.
         """
         return self._ps_processor
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_rule(self):
-        """
-        Specifies the used trimming rule.
-        """
-        warnings.warn(
-            "'trimming_rule' is deprecated and will be removed in a future version. ", DeprecationWarning, stacklevel=2
-        )
-        return self._trimming_rule
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_threshold(self):
-        """
-        Specifies the used trimming threshold.
-        """
-        warnings.warn(
-            "'trimming_threshold' is deprecated and will be removed in a future version. "
-            "Use 'ps_processor_config.clipping_threshold' or 'ps_processor.clipping_threshold' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._ps_processor.clipping_threshold
 
     def _initialize_ml_nuisance_params(self):
         valid_learner = ["ml_g0", "ml_g1", "ml_m", "ml_r0", "ml_r1"]

--- a/doubleml/irm/irm.py
+++ b/doubleml/irm/irm.py
@@ -24,7 +24,6 @@ from doubleml.utils.policytree import DoubleMLPolicyTree
 from doubleml.utils.propensity_score_processing import PSProcessorConfig, init_ps_processor
 
 
-# TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
 class DoubleMLIRM(LinearScoreMixin, DoubleML):
     """Double machine learning for interactive regression models
 
@@ -69,14 +68,6 @@ class DoubleMLIRM(LinearScoreMixin, DoubleML):
     normalize_ipw : bool
         Indicates whether the inverse probability weights are normalized.
         Default is ``False``.
-
-    trimming_rule : str, optional, deprecated
-        (DEPRECATED) A str (``'truncate'`` is the only choice) specifying the trimming approach.
-        Use `ps_processor_config` instead. Will be removed in a future version.
-
-    trimming_threshold : float, optional, deprecated
-        (DEPRECATED) The threshold used for trimming.
-        Use `ps_processor_config` instead. Will be removed in a future version.
 
     ps_processor_config : PSProcessorConfig, optional
         Configuration for propensity score processing (clipping, calibration, etc.).
@@ -136,8 +127,6 @@ class DoubleMLIRM(LinearScoreMixin, DoubleML):
         score="ATE",
         weights=None,
         normalize_ipw=False,
-        trimming_rule="truncate",  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        trimming_threshold=1e-2,  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
         ps_processor_config: Optional[PSProcessorConfig] = None,
         draw_sample_splitting=True,
     ):
@@ -174,12 +163,7 @@ class DoubleMLIRM(LinearScoreMixin, DoubleML):
                 "Normalization indicator has to be boolean. " + f"Object of type {str(type(self.normalize_ipw))} passed."
             )
 
-        # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        self._ps_processor_config, self._ps_processor = init_ps_processor(
-            ps_processor_config, trimming_rule, trimming_threshold
-        )
-        self._trimming_rule = trimming_rule
-        self._trimming_threshold = self._ps_processor.clipping_threshold
+        self._ps_processor_config, self._ps_processor = init_ps_processor(ps_processor_config)
 
         self._sensitivity_implemented = True
         self._external_predictions_implemented = True
@@ -207,31 +191,6 @@ class DoubleMLIRM(LinearScoreMixin, DoubleML):
         Propensity score processor.
         """
         return self._ps_processor
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_rule(self):
-        """
-        Specifies the used trimming rule.
-        """
-        warnings.warn(
-            "'trimming_rule' is deprecated and will be removed in a future version. ", DeprecationWarning, stacklevel=2
-        )
-        return self._trimming_rule
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_threshold(self):
-        """
-        Specifies the used trimming threshold.
-        """
-        warnings.warn(
-            "'trimming_threshold' is deprecated and will be removed in a future version. "
-            "Use 'ps_processor_config.clipping_threshold' or 'ps_processor.clipping_threshold' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._ps_processor.clipping_threshold
 
     @property
     def weights(self):

--- a/doubleml/irm/lpq.py
+++ b/doubleml/irm/lpq.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Optional
 
 import numpy as np
@@ -25,7 +24,6 @@ from doubleml.utils._tune_optuna import _dml_tune_optuna
 from doubleml.utils.propensity_score_processing import PSProcessorConfig, init_ps_processor
 
 
-# TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
 class DoubleMLLPQ(NonLinearScoreMixin, DoubleML):
     """Double machine learning for local potential quantiles
 
@@ -73,14 +71,6 @@ class DoubleMLLPQ(NonLinearScoreMixin, DoubleML):
         Default is ``'None'``, which uses :py:class:`statsmodels.nonparametric.kde.KDEUnivariate` with a
         gaussian kernel and silverman for bandwidth determination.
 
-    trimming_rule : str, optional, deprecated
-        (DEPRECATED) A str (``'truncate'`` is the only choice) specifying the trimming approach.
-        Use `ps_processor_config` instead. Will be removed in a future version.
-
-    trimming_threshold : float, optional, deprecated
-        (DEPRECATED) The threshold used for trimming.
-        Use `ps_processor_config` instead. Will be removed in a future version.
-
     ps_processor_config : PSProcessorConfig, optional
         Configuration for propensity score processing (clipping, calibration, etc.).
 
@@ -117,8 +107,6 @@ class DoubleMLLPQ(NonLinearScoreMixin, DoubleML):
         score="LPQ",
         normalize_ipw=True,
         kde=None,
-        trimming_rule="truncate",  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        trimming_threshold=1e-2,  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
         ps_processor_config: Optional[PSProcessorConfig] = None,
         draw_sample_splitting=True,
     ):
@@ -158,12 +146,7 @@ class DoubleMLLPQ(NonLinearScoreMixin, DoubleML):
 
         self._external_predictions_implemented = True
 
-        # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        self._ps_processor_config, self._ps_processor = init_ps_processor(
-            ps_processor_config, trimming_rule, trimming_threshold
-        )
-        self._trimming_rule = trimming_rule
-        self._trimming_threshold = self._ps_processor.clipping_threshold
+        self._ps_processor_config, self._ps_processor = init_ps_processor(ps_processor_config)
 
         _ = self._check_learner(ml_g, "ml_g", regressor=False, classifier=True)
         _ = self._check_learner(ml_m, "ml_m", regressor=False, classifier=True)
@@ -225,31 +208,6 @@ class DoubleMLLPQ(NonLinearScoreMixin, DoubleML):
         Propensity score processor.
         """
         return self._ps_processor
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_rule(self):
-        """
-        Specifies the used trimming rule.
-        """
-        warnings.warn(
-            "'trimming_rule' is deprecated and will be removed in a future version. ", DeprecationWarning, stacklevel=2
-        )
-        return self._trimming_rule
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_threshold(self):
-        """
-        Specifies the used trimming threshold.
-        """
-        warnings.warn(
-            "'trimming_threshold' is deprecated and will be removed in a future version. "
-            "Use 'ps_processor_config.clipping_threshold' or 'ps_processor.clipping_threshold' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._ps_processor.clipping_threshold
 
     @property
     def _score_element_names(self):

--- a/doubleml/irm/pq.py
+++ b/doubleml/irm/pq.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Optional
 
 import numpy as np
@@ -30,7 +29,6 @@ from doubleml.utils._tune_optuna import _dml_tune_optuna
 from doubleml.utils.propensity_score_processing import PSProcessorConfig, init_ps_processor
 
 
-# TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
 class DoubleMLPQ(NonLinearScoreMixin, DoubleML):
     """Double machine learning for potential quantiles
 
@@ -79,14 +77,6 @@ class DoubleMLPQ(NonLinearScoreMixin, DoubleML):
         Default is ``'None'``, which uses :py:class:`statsmodels.nonparametric.kde.KDEUnivariate` with a
         gaussian kernel and silverman for bandwidth determination.
 
-    trimming_rule : str, optional, deprecated
-        (DEPRECATED) A str (``'truncate'`` is the only choice) specifying the trimming approach.
-        Use `ps_processor_config` instead. Will be removed in a future version.
-
-    trimming_threshold : float, optional, deprecated
-        (DEPRECATED) The threshold used for trimming.
-        Use `ps_processor_config` instead. Will be removed in a future version.
-
     ps_processor_config : PSProcessorConfig, optional
         Configuration for propensity score processing (clipping, calibration, etc.).
 
@@ -123,8 +113,6 @@ class DoubleMLPQ(NonLinearScoreMixin, DoubleML):
         score="PQ",
         normalize_ipw=True,
         kde=None,
-        trimming_rule="truncate",  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        trimming_threshold=1e-2,  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
         ps_processor_config: Optional[PSProcessorConfig] = None,
         draw_sample_splitting=True,
     ):
@@ -164,12 +152,7 @@ class DoubleMLPQ(NonLinearScoreMixin, DoubleML):
 
         self._external_predictions_implemented = True
 
-        # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        self._ps_processor_config, self._ps_processor = init_ps_processor(
-            ps_processor_config, trimming_rule, trimming_threshold
-        )
-        self._trimming_rule = trimming_rule
-        self._trimming_threshold = self._ps_processor.clipping_threshold
+        self._ps_processor_config, self._ps_processor = init_ps_processor(ps_processor_config)
 
         _ = self._check_learner(ml_g, "ml_g", regressor=False, classifier=True)
         _ = self._check_learner(ml_m, "ml_m", regressor=False, classifier=True)
@@ -219,31 +202,6 @@ class DoubleMLPQ(NonLinearScoreMixin, DoubleML):
         Propensity score processor.
         """
         return self._ps_processor
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_rule(self):
-        """
-        Specifies the used trimming rule.
-        """
-        warnings.warn(
-            "'trimming_rule' is deprecated and will be removed in a future version. ", DeprecationWarning, stacklevel=2
-        )
-        return self._trimming_rule
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_threshold(self):
-        """
-        Specifies the used trimming threshold.
-        """
-        warnings.warn(
-            "'trimming_threshold' is deprecated and will be removed in a future version. "
-            "Use 'ps_processor_config.clipping_threshold' or 'ps_processor.clipping_threshold' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._ps_processor.clipping_threshold
 
     @property
     def _score_element_names(self):

--- a/doubleml/irm/qte.py
+++ b/doubleml/irm/qte.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Optional
 
 import numpy as np
@@ -19,7 +18,6 @@ from doubleml.utils._tune_optuna import TUNE_ML_MODELS_DOC
 from doubleml.utils.propensity_score_processing import PSProcessorConfig, init_ps_processor
 
 
-# TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
 class DoubleMLQTE(SampleSplittingMixin):
     """Double machine learning for quantile treatment effects
 
@@ -62,14 +60,6 @@ class DoubleMLQTE(SampleSplittingMixin):
         Default is ``'None'``, which uses :py:class:`statsmodels.nonparametric.kde.KDEUnivariate` with a
         gaussian kernel and silverman for bandwidth determination.
 
-    trimming_rule : str, optional, deprecated
-        (DEPRECATED) A str (``'truncate'`` is the only choice) specifying the trimming approach.
-        Use `ps_processor_config` instead. Will be removed in a future version.
-
-    trimming_threshold : float, optional, deprecated
-        (DEPRECATED) The threshold used for trimming.
-        Use `ps_processor_config` instead. Will be removed in a future version.
-
     ps_processor_config : PSProcessorConfig, optional
         Configuration for propensity score processing (clipping, calibration, etc.).
 
@@ -107,8 +97,6 @@ class DoubleMLQTE(SampleSplittingMixin):
         score="PQ",
         normalize_ipw=True,
         kde=None,
-        trimming_rule="truncate",  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        trimming_threshold=1e-2,  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
         ps_processor_config: Optional[PSProcessorConfig] = None,
         draw_sample_splitting=True,
     ):
@@ -140,12 +128,7 @@ class DoubleMLQTE(SampleSplittingMixin):
         # initialize framework which is constructed after the fit method is called
         self._framework = None
 
-        # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        self._ps_processor_config, self._ps_processor = init_ps_processor(
-            ps_processor_config, trimming_rule, trimming_threshold
-        )
-        self._trimming_rule = trimming_rule
-        self._trimming_threshold = self._ps_processor.clipping_threshold
+        self._ps_processor_config, self._ps_processor = init_ps_processor(ps_processor_config)
 
         if not isinstance(self.normalize_ipw, bool):
             raise TypeError(
@@ -275,31 +258,6 @@ class DoubleMLQTE(SampleSplittingMixin):
         Propensity score processor.
         """
         return self._ps_processor
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_rule(self):
-        """
-        Specifies the used trimming rule.
-        """
-        warnings.warn(
-            "'trimming_rule' is deprecated and will be removed in a future version. ", DeprecationWarning, stacklevel=2
-        )
-        return self._trimming_rule
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_threshold(self):
-        """
-        Specifies the used trimming threshold.
-        """
-        warnings.warn(
-            "'trimming_threshold' is deprecated and will be removed in a future version. "
-            "Use 'ps_processor_config.clipping_threshold' or 'ps_processor.clipping_threshold' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._ps_processor.clipping_threshold
 
     @property
     def coef(self):

--- a/doubleml/irm/ssm.py
+++ b/doubleml/irm/ssm.py
@@ -16,7 +16,6 @@ from doubleml.utils._tune_optuna import _dml_tune_optuna
 from doubleml.utils.propensity_score_processing import PSProcessorConfig, init_ps_processor
 
 
-# TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
 class DoubleMLSSM(LinearScoreMixin, DoubleML):
     """Double machine learning for sample selection models
 
@@ -52,14 +51,6 @@ class DoubleMLSSM(LinearScoreMixin, DoubleML):
     normalize_ipw : bool
         Indicates whether the inverse probability weights are normalized.
         Default is ``False``.
-
-    trimming_rule : str, optional, deprecated
-        (DEPRECATED) A str (``'truncate'`` is the only choice) specifying the trimming approach.
-        Use `ps_processor_config` instead. Will be removed in a future version.
-
-    trimming_threshold : float, optional, deprecated
-        (DEPRECATED) The threshold used for trimming.
-        Use `ps_processor_config` instead. Will be removed in a future version.
 
     ps_processor_config : PSProcessorConfig, optional
         Configuration for propensity score processing (clipping, calibration, etc.).
@@ -115,8 +106,6 @@ class DoubleMLSSM(LinearScoreMixin, DoubleML):
         n_rep=1,
         score="missing-at-random",
         normalize_ipw=False,
-        trimming_rule="truncate",  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        trimming_threshold=1e-2,  # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
         ps_processor_config: Optional[PSProcessorConfig] = None,
         draw_sample_splitting=True,
     ):
@@ -126,12 +115,7 @@ class DoubleMLSSM(LinearScoreMixin, DoubleML):
         self._sensitivity_implemented = False
         self._normalize_ipw = normalize_ipw
 
-        # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-        self._ps_processor_config, self._ps_processor = init_ps_processor(
-            ps_processor_config, trimming_rule, trimming_threshold
-        )
-        self._trimming_rule = trimming_rule
-        self._trimming_threshold = self._ps_processor.clipping_threshold
+        self._ps_processor_config, self._ps_processor = init_ps_processor(ps_processor_config)
 
         self._check_data(self._dml_data)
         self._is_cluster_data = self._dml_data.is_cluster_data
@@ -188,31 +172,6 @@ class DoubleMLSSM(LinearScoreMixin, DoubleML):
         Propensity score processor.
         """
         return self._ps_processor
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_rule(self):
-        """
-        Specifies the used trimming rule.
-        """
-        warnings.warn(
-            "'trimming_rule' is deprecated and will be removed in a future version. ", DeprecationWarning, stacklevel=2
-        )
-        return self._trimming_rule
-
-    # TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-    @property
-    def trimming_threshold(self):
-        """
-        Specifies the used trimming threshold.
-        """
-        warnings.warn(
-            "'trimming_threshold' is deprecated and will be removed in a future version. "
-            "Use 'ps_processor_config.clipping_threshold' or 'ps_processor.clipping_threshold' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._ps_processor.clipping_threshold
 
     def _initialize_ml_nuisance_params(self):
         valid_learner = ["ml_g_d0", "ml_g_d1", "ml_pi", "ml_m"]

--- a/doubleml/irm/tests/_utils_lpq_manual.py
+++ b/doubleml/irm/tests/_utils_lpq_manual.py
@@ -5,7 +5,7 @@ from sklearn.model_selection import StratifiedKFold, train_test_split
 
 from ...tests._utils import tune_grid_search
 from ...utils._estimation import _default_kde, _dml_cv_predict, _get_bracket_guess, _solve_ipw_score
-from ...utils._propensity_score import _normalize_ipw, _trimm
+from ...utils._propensity_score import _normalize_ipw
 
 
 def fit_lpq(
@@ -19,7 +19,6 @@ def fit_lpq(
     all_smpls,
     treatment,
     n_rep=1,
-    trimming_rule="truncate",
     clipping_threshold=1e-2,
     kde=_default_kde,
     normalize_ipw=True,
@@ -47,7 +46,6 @@ def fit_lpq(
             learner_m,
             smpls,
             treatment,
-            trimming_rule=trimming_rule,
             clipping_threshold=clipping_threshold,
             normalize_ipw=normalize_ipw,
             m_z_params=m_z_params,
@@ -79,7 +77,6 @@ def fit_nuisance_lpq(
     learner_m,
     smpls,
     treatment,
-    trimming_rule,
     clipping_threshold,
     normalize_ipw,
     m_z_params,
@@ -144,7 +141,7 @@ def fit_nuisance_lpq(
             "preds"
         ]
 
-        m_z_hat_prelim = _trimm(m_z_hat_prelim, trimming_rule, clipping_threshold)
+        m_z_hat_prelim = np.clip(m_z_hat_prelim, clipping_threshold, 1.0 - clipping_threshold)
         if normalize_ipw:
             m_z_hat_prelim = _normalize_ipw(m_z_hat_prelim, z_train_1)
 
@@ -222,7 +219,7 @@ def fit_nuisance_lpq(
         m_d_z1_hat[test_inds] = ml_m_d_z1.predict_proba(x[test_inds, :])[:, 1]
 
     # clip propensities
-    m_z_hat = _trimm(m_z_hat, trimming_rule, clipping_threshold)
+    m_z_hat = np.clip(m_z_hat, clipping_threshold, 1.0 - clipping_threshold)
 
     if normalize_ipw:
         m_z_hat = _normalize_ipw(m_z_hat, z)

--- a/doubleml/irm/tests/_utils_qte_manual.py
+++ b/doubleml/irm/tests/_utils_qte_manual.py
@@ -4,6 +4,7 @@ from sklearn.base import clone
 from ...data.base_data import DoubleMLData
 from ...tests._utils_boot import draw_weights
 from ...utils._estimation import _default_kde
+from ...utils.propensity_score_processing import PSProcessorConfig
 from ..pq import DoubleMLPQ
 
 
@@ -16,8 +17,7 @@ def fit_qte(
     learner_m,
     all_smpls,
     n_rep=1,
-    trimming_rule="truncate",
-    trimming_threshold=1e-2,
+    clipping_threshold=1e-2,
     kde=_default_kde,
     normalize_ipw=True,
     draw_sample_splitting=True,
@@ -43,8 +43,7 @@ def fit_qte(
             treatment=0,
             n_folds=n_folds,
             n_rep=n_rep,
-            trimming_rule=trimming_rule,
-            trimming_threshold=trimming_threshold,
+            ps_processor_config=PSProcessorConfig(clipping_threshold=clipping_threshold),
             kde=kde,
             normalize_ipw=normalize_ipw,
             draw_sample_splitting=False,
@@ -57,8 +56,7 @@ def fit_qte(
             treatment=1,
             n_folds=n_folds,
             n_rep=n_rep,
-            trimming_rule=trimming_rule,
-            trimming_threshold=trimming_threshold,
+            ps_processor_config=PSProcessorConfig(clipping_threshold=clipping_threshold),
             kde=kde,
             normalize_ipw=normalize_ipw,
             draw_sample_splitting=False,

--- a/doubleml/irm/tests/_utils_ssm_manual.py
+++ b/doubleml/irm/tests/_utils_ssm_manual.py
@@ -4,7 +4,6 @@ from sklearn.model_selection import train_test_split
 
 from ...tests._utils import fit_predict, fit_predict_proba, tune_grid_search
 from ...utils._estimation import _predict_zero_one_propensity
-from ...utils._propensity_score import _trimm
 
 
 def fit_selection(
@@ -18,7 +17,6 @@ def fit_selection(
     learner_m,
     all_smpls,
     score,
-    trimming_rule="truncate",
     clipping_threshold=1e-2,
     normalize_ipw=True,
     n_rep=1,
@@ -54,7 +52,6 @@ def fit_selection(
             learner_m,
             smpls,
             score,
-            trimming_rule=trimming_rule,
             clipping_threshold=clipping_threshold,
             g_d0_params=g_d0_params,
             g_d1_params=g_d1_params,
@@ -107,7 +104,6 @@ def fit_nuisance_selection(
     learner_m,
     smpls,
     score,
-    trimming_rule="truncate",
     clipping_threshold=1e-2,
     g_d0_params=None,
     g_d1_params=None,
@@ -212,7 +208,7 @@ def fit_nuisance_selection(
             # predict conditional outcome
             g_hat_d0 = ml_g_d0.predict(xpi_test)
 
-            m_hat = _trimm(m_hat, trimming_rule, clipping_threshold)
+            m_hat = np.clip(m_hat, clipping_threshold, 1.0 - clipping_threshold)
 
             # append predictions on test sample to final list of predictions
             g_hat_d1_list.append(g_hat_d1)

--- a/doubleml/irm/tests/test_qte.py
+++ b/doubleml/irm/tests/test_qte.py
@@ -9,6 +9,7 @@ from sklearn.linear_model import LogisticRegression
 
 import doubleml as dml
 from doubleml.irm.datasets import make_irm_data
+from doubleml.utils import PSProcessorConfig
 
 from ...tests._utils import confint_manual, draw_smpls
 from ...utils._estimation import _default_kde
@@ -55,7 +56,7 @@ def dml_qte_fixture(generate_data_quantiles, learner, normalize_ipw, kde):
         "n_folds": n_folds,
         "n_rep": n_rep,
         "normalize_ipw": normalize_ipw,
-        "trimming_threshold": 1e-12,
+        "ps_processor_config": PSProcessorConfig(clipping_threshold=1e-12),
         "kde": kde,
     }
 
@@ -84,8 +85,7 @@ def dml_qte_fixture(generate_data_quantiles, learner, normalize_ipw, kde):
         all_smpls,
         n_rep=n_rep,
         normalize_ipw=normalize_ipw,
-        trimming_rule="truncate",
-        trimming_threshold=1e-12,
+        clipping_threshold=1e-12,
         kde=kde,
         draw_sample_splitting=True,
     )

--- a/doubleml/irm/tests/test_ssm.py
+++ b/doubleml/irm/tests/test_ssm.py
@@ -93,7 +93,6 @@ def dml_selection_fixture(
         clone(learner[1]),
         all_smpls,
         score,
-        trimming_rule="truncate",
         clipping_threshold=clipping_threshold,
         normalize_ipw=normalize_ipw,
     )

--- a/doubleml/tests/test_evaluate_learner.py
+++ b/doubleml/tests/test_evaluate_learner.py
@@ -30,18 +30,18 @@ def n_rep(request):
 
 
 @pytest.fixture(scope="module", params=[0.01, 0.05])
-def trimming_threshold(request):
-    return request.param
+def ps_processor_config(request):
+    return dml.utils.PSProcessorConfig(clipping_threshold=request.param)
 
 
 @pytest.fixture(scope="module")
-def dml_irm_eval_learner_fixture(learner, trimming_threshold, n_rep):
+def dml_irm_eval_learner_fixture(learner, ps_processor_config, n_rep):
     # Set machine learning methods for m & g
     ml_g = clone(learner[0])
     ml_m = clone(learner[1])
 
     np.random.seed(3141)
-    dml_irm_obj = dml.DoubleMLIRM(obj_dml_data, ml_g, ml_m, n_folds=2, n_rep=n_rep, trimming_threshold=trimming_threshold)
+    dml_irm_obj = dml.DoubleMLIRM(obj_dml_data, ml_g, ml_m, n_folds=2, n_rep=n_rep, ps_processor_config=ps_processor_config)
     dml_irm_obj.fit()
     res_manual = dml_irm_obj.evaluate_learners(learners=["ml_g0", "ml_g1"])
     res_manual["ml_m"] = dml_irm_obj.evaluate_learners(learners=["ml_m"], metric=_logloss)["ml_m"]

--- a/doubleml/tests/test_return_types.py
+++ b/doubleml/tests/test_return_types.py
@@ -25,6 +25,7 @@ from doubleml import (
 from doubleml.did.datasets import make_did_SZ2020
 from doubleml.irm.datasets import make_iivm_data, make_irm_data, make_ssm_data
 from doubleml.plm.datasets import make_pliv_CHS2015, make_pliv_multiway_cluster_CKMS2021, make_plr_CCDDHNR2018
+from doubleml.utils import PSProcessorConfig
 
 np.random.seed(3141)
 n_obs = 200
@@ -125,7 +126,14 @@ pliv_obj = DoubleMLPLIV(dml_data_pliv, Lasso(), Lasso(), Lasso(), n_rep=n_rep, n
 pliv_obj.fit()
 pliv_obj.bootstrap(n_rep_boot=n_rep_boot)
 
-irm_obj = DoubleMLIRM(dml_data_irm, Lasso(), LogisticRegression(), n_rep=n_rep, n_folds=n_folds, trimming_threshold=0.1)
+irm_obj = DoubleMLIRM(
+    dml_data_irm,
+    Lasso(),
+    LogisticRegression(),
+    n_rep=n_rep,
+    n_folds=n_folds,
+    ps_processor_config=PSProcessorConfig(clipping_threshold=0.1),
+)
 irm_obj.fit()
 irm_obj.bootstrap(n_rep_boot=n_rep_boot)
 

--- a/doubleml/utils/_checks.py
+++ b/doubleml/utils/_checks.py
@@ -129,26 +129,6 @@ def _check_score(score, valid_score, allow_callable=True):
     return
 
 
-def _check_trimming(trimming_rule, trimming_threshold):
-    valid_trimming_rule = ["truncate"]
-    if trimming_rule not in valid_trimming_rule:
-        raise ValueError(
-            "Invalid trimming_rule "
-            + str(trimming_rule)
-            + ". "
-            + "Valid trimming_rule "
-            + " or ".join(valid_trimming_rule)
-            + "."
-        )
-    if not isinstance(trimming_threshold, float):
-        raise TypeError("trimming_threshold has to be a float. " + f"Object of type {str(type(trimming_threshold))} passed.")
-    if (trimming_threshold <= 0) | (trimming_threshold >= 0.5):
-        raise ValueError(
-            "Invalid trimming_threshold " + str(trimming_threshold) + ". " + "trimming_threshold has to be between 0 and 0.5."
-        )
-    return
-
-
 def _check_zero_one_treatment(obj_dml):
     one_treat = obj_dml._dml_data.n_treat == 1
     binary_treat = type_of_target(obj_dml._dml_data.d) == "binary"

--- a/doubleml/utils/_propensity_score.py
+++ b/doubleml/utils/_propensity_score.py
@@ -11,15 +11,6 @@ def _propensity_score_adjustment(propensity_score, treatment_indicator, normaliz
     return adjusted_propensity_score
 
 
-def _trimm(preds, trimming_rule, trimming_threshold):
-    """Trim predictions based on the specified method and threshold."""
-    if trimming_rule == "truncate":
-        adjusted_predictions = np.clip(a=preds, a_min=trimming_threshold, a_max=1 - trimming_threshold)
-    else:
-        adjusted_predictions = preds
-    return adjusted_predictions
-
-
 def _normalize_ipw(propensity_score, treatment_indicator):
     """Normalize inverse probability weights."""
     mean_treat1 = np.mean(np.divide(treatment_indicator, propensity_score))

--- a/doubleml/utils/propensity_score_processing.py
+++ b/doubleml/utils/propensity_score_processing.py
@@ -56,28 +56,11 @@ class PSProcessorConfig:
     cv_calibration: bool = False
 
 
-# TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
-def init_ps_processor(
-    ps_processor_config: Optional[PSProcessorConfig], trimming_rule: Optional[str], trimming_threshold: Optional[float]
-):
-    if trimming_rule != "truncate":
-        warnings.warn(
-            "'trimming_rule' is deprecated and will be removed in a future version. "
-            "Use 'ps_processor_config' with 'clipping_threshold' instead.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-    if trimming_threshold != 1e-2:
-        warnings.warn(
-            "'trimming_threshold' is deprecated and will be removed in a future version. "
-            "Use 'ps_processor_config' with 'clipping_threshold' instead.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
+def init_ps_processor(ps_processor_config: Optional[PSProcessorConfig]):
     if ps_processor_config is not None:
         config = ps_processor_config
     else:
-        config = PSProcessorConfig(clipping_threshold=trimming_threshold if trimming_threshold is not None else 1e-2)
+        config = PSProcessorConfig()
     processor = PSProcessor.from_config(config)
     return config, processor
 

--- a/doubleml/utils/tests/test_ps_processor.py
+++ b/doubleml/utils/tests/test_ps_processor.py
@@ -1,4 +1,3 @@
-import warnings
 from unittest.mock import patch
 
 import numpy as np
@@ -9,21 +8,18 @@ from sklearn.model_selection import KFold, cross_val_predict
 from doubleml.utils.propensity_score_processing import PSProcessor, PSProcessorConfig, init_ps_processor
 
 
-# TODO [v0.12.0]: Remove support for 'trimming_rule' and 'trimming_threshold' (deprecated).
 @pytest.mark.ci
-def test_init_ps_processor_with_deprecated():
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        cfg, proc = init_ps_processor(None, "truncate", 0.02)
-        assert any("deprecated" in str(warn.message) for warn in w)
-        assert isinstance(cfg, PSProcessorConfig)
-        assert proc.clipping_threshold == 0.02
+def test_init_ps_processor_with_default_config():
+    cfg, proc = init_ps_processor(None)
+    assert isinstance(cfg, PSProcessorConfig)
+    assert isinstance(proc, PSProcessor)
+    assert proc.clipping_threshold == PSProcessorConfig().clipping_threshold
 
 
 @pytest.mark.ci
 def test_init_ps_processor_with_config():
     config = PSProcessorConfig(clipping_threshold=0.05)
-    cfg, proc = init_ps_processor(config, None, None)
+    cfg, proc = init_ps_processor(config)
     assert isinstance(cfg, PSProcessorConfig)
     assert isinstance(proc, PSProcessor)
     assert proc.clipping_threshold == 0.05


### PR DESCRIPTION
## Summary
- remove deprecated `trimming_rule` and `trimming_threshold` from DID and IRM model APIs
- simplify propensity score processor initialization around `PSProcessorConfig`
- update GitHub Actions to Node 24-compatible action versions

Closes #364.
Closes #396.

## Tests
- `pre-commit run --all-files --show-diff-on-failure`
- Python 3.10/3.11/3.13: doctest, `pytest -m ci`, `pytest -m ci_rdd`
- Python 3.12: `pytest --cov=./ --cov-report=xml --cov-report=html`