### PR TITLE
Fix bug where DoubleMLLPLR was normalising by outer folds

### DIFF
--- a/doubleml/utils/_estimation.py
+++ b/doubleml/utils/_estimation.py
@@ -220,13 +220,14 @@ def _double_dml_cv_predict(
 
         res["preds_inner"].append(res_inner["preds"])
         res["targets_inner"].append(res_inner["targets"])
+        test_idx = smpls_single_split[1]
         for model in res_inner["models"]:
             res["models"].append(model)
             if method == "predict_proba":
-                res["preds"][smpls_single_split[1]] += model.predict_proba(x[smpls_single_split[1]])[:, 1]
+                res["preds"][test_idx] += model.predict_proba(x[test_idx])[:, 1]
             else:
-                res["preds"][smpls_single_split[1]] += model.predict(x[smpls_single_split[1]])
-    res["preds"] /= len(smpls)
+                res["preds"][test_idx] += model.predict(x[test_idx])
+        res["preds"][test_idx] /= len(res_inner["models"])
     res["targets"] = np.copy(y)
     return res
 

--- a/doubleml/utils/tests/test_cv_predict.py
+++ b/doubleml/utils/tests/test_cv_predict.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pytest
+from sklearn.dummy import DummyRegressor
+
+from doubleml.utils._estimation import _double_dml_cv_predict
+
+
+@pytest.mark.ci
+def test_double_dml_cv_predict_uses_inner_fold_count():
+    X = np.arange(12).reshape(-1, 1)
+    y = np.zeros(12)
+
+    smpls = [
+        (np.array([0, 1, 2, 3, 4, 5]), np.array([6, 7, 8, 9, 10, 11])),
+        (np.array([6, 7, 8, 9, 10, 11]), np.array([0, 1, 2, 3, 4, 5])),
+    ]
+
+    smpls_inner = [
+        [
+            (np.array([0, 1, 2]), np.array([3, 4])),
+            (np.array([3, 4, 5]), np.array([0, 1])),
+            (np.array([0, 1, 5]), np.array([2, 3])),
+        ],
+        [
+            (np.array([6, 7]), np.array([8, 9])),
+            (np.array([8, 9, 10]), np.array([6, 7])),
+        ],
+    ]
+
+    out = _double_dml_cv_predict(
+        DummyRegressor(strategy="constant", constant=7.0),
+        "ml_M",
+        X,
+        y,
+        smpls=smpls,
+        smpls_inner=smpls_inner,
+    )
+
+    assert np.allclose(out["preds"][smpls[0][1]], 7.0)
+    assert np.allclose(out["preds"][smpls[1][1]], 7.0)


### PR DESCRIPTION
### Description

This PR changes a few lines of code so that the `_double_dml_cv_predict()` function correctly normalises by inner folds. 

### Reference to Issues or PRs
Fixes #401, where the DoubleMLLPLR model would produce incorrect coefficient estimates when `n_folds != n_folds_inner`. 


### PR Checklist
Please fill out this PR checklist (see our [contributing guidelines](https://github.com/DoubleML/doubleml-for-py/blob/main/CONTRIBUTING.md#checklist-for-pull-requests-pr) for details).

- [x] The title of the pull request summarizes the changes made.
- [x] The PR contains a detailed description of all changes and additions.
- [x] References to related issues or PRs are added.
- [x] The code passes all (unit) tests - I have not run the full test suite but only targeted tests for the LPLR model. The function `_double_dml_cv_predict()` is only used in `plm/lplr.py` so should not have any effects on other functionality.
- [ ] Enhancements or new feature are equipped with unit tests. **(N/A)** - bug fix only.
- [x] The changes adhere to the PEP8 standards.
